### PR TITLE
✨feat: implement chore create & list API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0' // Swagger
 }
 
 tasks.named('test') {

--- a/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
+++ b/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
@@ -2,6 +2,7 @@ package com.homeprotectors.backend.controller;
 
 import com.homeprotectors.backend.dto.chore.ChoreCreateRequest;
 import com.homeprotectors.backend.dto.chore.ChoreCreateResponse;
+import com.homeprotectors.backend.dto.chore.ChoreListItemResponse;
 import com.homeprotectors.backend.dto.common.ResponseDTO;
 import com.homeprotectors.backend.entity.Chore;
 import com.homeprotectors.backend.service.ChoreService;
@@ -12,6 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chores")
@@ -19,7 +22,7 @@ public class ChoreController {
 
     private final ChoreService choreService;
 
-    @Operation(summary = "Create com.homeprotectors.backend.entity.Chore", description = "새로운 집안일(chore)을 등록합니다.")
+    @Operation(summary = "Create com.homeprotectors.backend.entity.Chore", description = "Create a new chore")
     @PostMapping
     public ResponseEntity<ResponseDTO<ChoreCreateResponse>> createChore(@Valid @RequestBody ChoreCreateRequest request) {
         Chore chore = choreService.createChore(request);
@@ -35,4 +38,12 @@ public class ChoreController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new ResponseDTO<>(true, "Chore created successfully", response));
     }
+
+    @Operation(summary = "chore 목록 조회", description = "로그인 사용자의 그룹에 속한 모든 chore 목록을 조회합니다.")
+    @GetMapping
+    public ResponseDTO<List<ChoreListItemResponse>> getChoreList() {
+        List<ChoreListItemResponse> chores = choreService.getChoreList();  // 인증 기반 그룹 필터링 가정
+        return new ResponseDTO<>(true, "Chore list retrieved", chores);
+    }
+
 }

--- a/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
+++ b/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
@@ -1,0 +1,38 @@
+package com.homeprotectors.backend.controller;
+
+import com.homeprotectors.backend.dto.chore.ChoreCreateRequest;
+import com.homeprotectors.backend.dto.chore.ChoreCreateResponse;
+import com.homeprotectors.backend.dto.common.ResponseDTO;
+import com.homeprotectors.backend.entity.Chore;
+import com.homeprotectors.backend.service.ChoreService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chores")
+public class ChoreController {
+
+    private final ChoreService choreService;
+
+    @Operation(summary = "Create com.homeprotectors.backend.entity.Chore", description = "새로운 집안일(chore)을 등록합니다.")
+    @PostMapping
+    public ResponseEntity<ResponseDTO<ChoreCreateResponse>> createChore(@Valid @RequestBody ChoreCreateRequest request) {
+        Chore chore = choreService.createChore(request);
+
+        ChoreCreateResponse response = new ChoreCreateResponse(
+                chore.getId(),
+                chore.getTitle(),
+                chore.getCycleDays(),
+                chore.getReminderEnabled(),
+                chore.getReminderDays()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ResponseDTO<>(true, "Chore created successfully", response));
+    }
+}

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCreateRequest.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCreateRequest.java
@@ -1,0 +1,27 @@
+package com.homeprotectors.backend.dto.chore;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Chore 생성할 때 사용자가 입력하는 데이터")
+public class ChoreCreateRequest {
+
+    @NotBlank
+    private String title;
+
+    @NotNull
+    private Integer cycleDays;
+    private LocalDate startDate;
+    private Boolean reminderEnabled;
+
+    private Integer reminderDays; // optional
+}

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCreateResponse.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCreateResponse.java
@@ -1,0 +1,21 @@
+package com.homeprotectors.backend.dto.chore;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Chore 생성 API의 응답 데이터")
+public class ChoreCreateResponse {
+    private Long id;
+    private String title;
+    private Integer cycleDays;
+    private Boolean reminderEnabled;
+    private Integer reminderDays;
+}

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreListItemResponse.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreListItemResponse.java
@@ -1,0 +1,30 @@
+package com.homeprotectors.backend.dto.chore;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "chore item list response DTO")
+public class ChoreListItemResponse {
+
+    @Schema(description = "chore ID")
+    private Long id;
+
+    @Schema(description = "chore title")
+    private String title;
+
+    @Schema(description = "repeat cycle (day)")
+    private Integer cycleDays;
+
+    @Schema(description = "next due date")
+    private LocalDate nextDue;
+
+    @Schema(description = "enable reminder option")
+    private Boolean reminderEnabled;
+}

--- a/src/main/java/com/homeprotectors/backend/dto/common/ResponseDTO.java
+++ b/src/main/java/com/homeprotectors/backend/dto/common/ResponseDTO.java
@@ -1,0 +1,16 @@
+package com.homeprotectors.backend.dto.common;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "공통 API 응답 기본 구조")
+public class ResponseDTO<T> {
+    private boolean success;
+    private String message;
+    private T data;
+}

--- a/src/main/java/com/homeprotectors/backend/entity/Chore.java
+++ b/src/main/java/com/homeprotectors/backend/entity/Chore.java
@@ -1,0 +1,43 @@
+package com.homeprotectors.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chores")
+@Data
+public class Chore {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long groupId;
+
+    @Column(nullable = false)
+    private String title;
+
+    private Integer cycleDays;
+    private LocalDate lastDone;
+    private LocalDate nextDue;
+    private LocalDate reminderDate;
+    @Setter
+    @Getter
+    private Boolean reminderEnabled = true;
+    private Integer reminderDays;
+
+    @Column(nullable = false)
+    private Long createdBy;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+//  com.homeprotectors.backend.entity.Group Entity 우선 주석처리 - 향후 기능 확장
+//    @ManyToOne
+//    @JoinColumn(name = "group_id")
+//    private com.homeprotectors.backend.entity.Group group;
+}

--- a/src/main/java/com/homeprotectors/backend/entity/ChoreHistory.java
+++ b/src/main/java/com/homeprotectors/backend/entity/ChoreHistory.java
@@ -1,0 +1,38 @@
+package com.homeprotectors.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import jakarta.persistence.Id;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chore_history")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChoreHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chore_id", nullable = false)
+    private Chore chore;
+
+    @Column(nullable = false)
+    private LocalDate scheduledDate; // 예정 추천일
+
+    private LocalDate doneDate;       // 실제 완료한 날짜 (완료한 경우만)
+
+    private Boolean isDone = false;   // 완료 여부
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/com/homeprotectors/backend/entity/Group.java
+++ b/src/main/java/com/homeprotectors/backend/entity/Group.java
@@ -1,0 +1,31 @@
+package com.homeprotectors.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "groups")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Group {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String inviteCode;
+
+    private LocalDate createdAt;
+
+//    @OneToMany(mappedBy = "group")
+//    private List<User> users;  // 선택사항
+}

--- a/src/main/java/com/homeprotectors/backend/repository/ChoreRepository.java
+++ b/src/main/java/com/homeprotectors/backend/repository/ChoreRepository.java
@@ -1,0 +1,9 @@
+package com.homeprotectors.backend.repository;
+
+import com.homeprotectors.backend.entity.Chore;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChoreRepository extends JpaRepository<Chore, Long> {
+}

--- a/src/main/java/com/homeprotectors/backend/repository/ChoreRepository.java
+++ b/src/main/java/com/homeprotectors/backend/repository/ChoreRepository.java
@@ -4,6 +4,11 @@ import com.homeprotectors.backend.entity.Chore;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ChoreRepository extends JpaRepository<Chore, Long> {
+    List<Chore> findByGroupId(Long groupId);
 }
+
+

--- a/src/main/java/com/homeprotectors/backend/repository/GroupRepository.java
+++ b/src/main/java/com/homeprotectors/backend/repository/GroupRepository.java
@@ -1,0 +1,9 @@
+package com.homeprotectors.backend.repository;
+
+import com.homeprotectors.backend.entity.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GroupRepository extends JpaRepository<Group, Long> {
+}

--- a/src/main/java/com/homeprotectors/backend/service/ChoreService.java
+++ b/src/main/java/com/homeprotectors/backend/service/ChoreService.java
@@ -1,0 +1,40 @@
+package com.homeprotectors.backend.service;
+
+import com.homeprotectors.backend.dto.chore.ChoreCreateRequest;
+import com.homeprotectors.backend.entity.Chore;
+import com.homeprotectors.backend.repository.ChoreRepository;
+import com.homeprotectors.backend.repository.GroupRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ChoreService {
+
+    private final ChoreRepository choreRepository;
+    private final GroupRepository groupRepository; // TODO: 그룹 기능 추후 추가
+
+    public Chore createChore(@Valid ChoreCreateRequest request) {
+        Chore chore = new Chore();
+        chore.setGroupId(1L); // TODO: 임시 group ID
+        chore.setTitle(request.getTitle());
+        chore.setCycleDays(request.getCycleDays());
+        chore.setReminderEnabled(request.getReminderEnabled());
+        chore.setReminderDays(request.getReminderDays());
+        chore.setCreatedBy(1L); // TODO: 임시 user ID. 나중에 JWT 인증 적용해서 동적으로 변경
+        chore.setCreatedAt(LocalDateTime.now());
+
+        // nextDue 계산
+        LocalDate baseDate = (request.getStartDate() != null) ? request.getStartDate() : LocalDate.now();
+        if (request.getCycleDays() != null) {
+            chore.setNextDue(baseDate.plusDays(request.getCycleDays()));
+        }
+
+
+        return choreRepository.save(chore);
+    }
+}

--- a/src/main/java/com/homeprotectors/backend/service/ChoreService.java
+++ b/src/main/java/com/homeprotectors/backend/service/ChoreService.java
@@ -1,6 +1,7 @@
 package com.homeprotectors.backend.service;
 
 import com.homeprotectors.backend.dto.chore.ChoreCreateRequest;
+import com.homeprotectors.backend.dto.chore.ChoreListItemResponse;
 import com.homeprotectors.backend.entity.Chore;
 import com.homeprotectors.backend.repository.ChoreRepository;
 import com.homeprotectors.backend.repository.GroupRepository;
@@ -10,6 +11,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -37,4 +40,20 @@ public class ChoreService {
 
         return choreRepository.save(chore);
     }
+
+    public List<ChoreListItemResponse> getChoreList() {
+        Long groupId = 1L; // TODO: 인증 기반으로 동적으로 받을 예정
+
+        List<Chore> chores = choreRepository.findByGroupId(groupId);
+        return chores.stream()
+                .map(c -> new ChoreListItemResponse(
+                        c.getId(),
+                        c.getTitle(),
+                        c.getCycleDays(),
+                        c.getNextDue(),
+                        c.getReminderEnabled()
+                ))
+                .collect(Collectors.toList());
+    }
+
 }


### PR DESCRIPTION
## 🔍 Overview

This PR adds backend support for chore creation and list retrieval.  
It also defines the related entities (Chore, Group) and applies a unified response DTO format.  

## ✨ Changes

- `POST /api/chores`: Create a new chore with validation
- `GET /api/chores`: Retrieve list of chores for a group
- Added `Chore`, `Group` entity and repository
- Applied `ResponseDTO<T>` format for consistent API responses

## 📸 Screenshots

N/A (backend only)

## 🔗 Related Task

- Jira: [HOME-12 - Implement API endpoint to create a chore](https://home-protectors.atlassian.net/browse/HOME-12?atlOrigin=eyJpIjoiY2UyNzVmYmFjNDBjNDk2MDk2NGY3N2IyMzkwOGU5YjIiLCJwIjoiaiJ9)
- Jira: [HOME-40 - Implement API endpoint to retrieve a chore list](https://home-protectors.atlassian.net/browse/HOME-40?atlOrigin=eyJpIjoiMTk0YWVlYmZlNGUxNGZiNTgxOWYyMTMxN2QzYjQ2YWUiLCJwIjoiaiJ9)

## 💬 Additional Notes

- Currently uses temporary groupId/userId (1L) – will be replaced with JWT-based user info later