### PR TITLE
implement edit & delete chore API

### DIFF
--- a/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
+++ b/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
@@ -2,6 +2,7 @@ package com.homeprotectors.backend.controller;
 
 import com.homeprotectors.backend.dto.chore.ChoreCreateRequest;
 import com.homeprotectors.backend.dto.chore.ChoreCreateResponse;
+import com.homeprotectors.backend.dto.chore.ChoreEditRequest;
 import com.homeprotectors.backend.dto.chore.ChoreListItemResponse;
 import com.homeprotectors.backend.dto.common.ResponseDTO;
 import com.homeprotectors.backend.entity.Chore;
@@ -30,6 +31,7 @@ public class ChoreController {
         ChoreCreateResponse response = new ChoreCreateResponse(
                 chore.getId(),
                 chore.getTitle(),
+                chore.getStartDate(),
                 chore.getCycleDays(),
                 chore.getReminderEnabled(),
                 chore.getReminderDays()
@@ -39,11 +41,32 @@ public class ChoreController {
                 .body(new ResponseDTO<>(true, "Chore created successfully", response));
     }
 
-    @Operation(summary = "chore 목록 조회", description = "로그인 사용자의 그룹에 속한 모든 chore 목록을 조회합니다.")
+    @Operation(summary = "chore 목록 조회", description = "Retrieve the list of chores in the group that the user belongs to")
     @GetMapping
     public ResponseDTO<List<ChoreListItemResponse>> getChoreList() {
         List<ChoreListItemResponse> chores = choreService.getChoreList();  // 인증 기반 그룹 필터링 가정
         return new ResponseDTO<>(true, "Chore list retrieved", chores);
     }
+
+    @Operation(summary = "chore 수정", description = "Edit an existing chore")
+    @PutMapping("/{choreId}")
+    public ResponseEntity<ResponseDTO<ChoreCreateResponse>> editChore(
+            @PathVariable Long choreId,
+            @RequestBody ChoreEditRequest request) {
+
+        Chore updated = choreService.editChore(choreId, request);
+
+        ChoreCreateResponse response = new ChoreCreateResponse(
+                updated.getId(),
+                updated.getTitle(),
+                updated.getStartDate(),
+                updated.getCycleDays(),
+                updated.getReminderEnabled(),
+                updated.getReminderDays()
+        );
+
+        return ResponseEntity.ok(new ResponseDTO<>(true, "Chore updated successfully", response));
+    }
+
 
 }

--- a/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
+++ b/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
@@ -68,5 +68,13 @@ public class ChoreController {
         return ResponseEntity.ok(new ResponseDTO<>(true, "Chore updated successfully", response));
     }
 
+    @Operation(summary = "chore 삭제", description = "Delete a chore by ID")
+    @DeleteMapping("/{choreId}")
+    public ResponseEntity<Void> deleteChore(@PathVariable Long choreId) {
+        choreService.deleteChore(choreId);
+        return ResponseEntity.noContent().build(); // 204 No Content
+    }
+
+
 
 }

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCreateRequest.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCreateRequest.java
@@ -23,7 +23,6 @@ public class ChoreCreateRequest {
     @Max(value = 365, message = "반복 주기는 365일 이하여야 합니다.")
     private Integer cycleDays;
 
-    @NotNull
     private LocalDate startDate;
 
     private Boolean reminderEnabled;

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCreateResponse.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCreateResponse.java
@@ -15,6 +15,7 @@ import java.time.LocalTime;
 public class ChoreCreateResponse {
     private Long id;
     private String title;
+    private LocalDate startDate;
     private Integer cycleDays;
     private Boolean reminderEnabled;
     private Integer reminderDays;

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreEditRequest.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreEditRequest.java
@@ -1,0 +1,37 @@
+package com.homeprotectors.backend.dto.chore;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Chore 업데이트될 데이터")
+public class ChoreEditRequest {
+
+    @Schema(description = "Title of the chore", example = "Vacuuming")
+    private String title;
+
+    @Schema(description = "Cycle in days", example = "7")
+    @Min(value = 1, message = "반복 주기는 1일 이상이어야 합니다.")
+    @Max(value = 365, message = "반복 주기는 365일 이하여야 합니다.")
+    private Integer cycleDays;
+
+    @Schema(description = "Start date to calculate next due date", example = "2025-05-10")
+    private LocalDate startDate;
+
+    @Schema(description = "Whether reminder is enabled", example = "true")
+    private Boolean reminderEnabled;
+
+    @Schema(description = "Number of days before due date to trigger reminder", example = "1")
+    @Min(value = 0, message = "미리 알림 일수는 0일 이상 입력해주세요.")
+    private Integer reminderDays;
+
+}

--- a/src/main/java/com/homeprotectors/backend/entity/Chore.java
+++ b/src/main/java/com/homeprotectors/backend/entity/Chore.java
@@ -22,6 +22,7 @@ public class Chore {
     private String title;
 
     private Integer cycleDays;
+    private LocalDate startDate;
     private LocalDate lastDone;
     private LocalDate nextDue;
     private LocalDate reminderDate;

--- a/src/main/java/com/homeprotectors/backend/service/ChoreService.java
+++ b/src/main/java/com/homeprotectors/backend/service/ChoreService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Data
@@ -114,6 +115,15 @@ public class ChoreService {
 
         return choreRepository.save(chore);
     }
+
+    public void deleteChore(Long choreId) {
+        Chore chore = choreRepository.findById(choreId)
+                .orElseThrow(() -> new NoSuchElementException("해당 chore가 존재하지 않습니다."));
+
+        // TODO: 인증 사용자 그룹 소속 여부 확인 필요 (JWT 인증 후 구현 예정)
+        choreRepository.delete(chore);
+    }
+
 
 
 }

--- a/src/main/java/com/homeprotectors/backend/service/ChoreService.java
+++ b/src/main/java/com/homeprotectors/backend/service/ChoreService.java
@@ -1,11 +1,14 @@
 package com.homeprotectors.backend.service;
 
 import com.homeprotectors.backend.dto.chore.ChoreCreateRequest;
+import com.homeprotectors.backend.dto.chore.ChoreEditRequest;
 import com.homeprotectors.backend.dto.chore.ChoreListItemResponse;
 import com.homeprotectors.backend.entity.Chore;
 import com.homeprotectors.backend.repository.ChoreRepository;
 import com.homeprotectors.backend.repository.GroupRepository;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +17,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Data
 @Service
 @RequiredArgsConstructor
 public class ChoreService {
@@ -32,11 +36,19 @@ public class ChoreService {
         chore.setCreatedAt(LocalDateTime.now());
 
         // nextDue 계산
-        LocalDate baseDate = (request.getStartDate() != null) ? request.getStartDate() : LocalDate.now();
-        if (request.getCycleDays() != null) {
-            chore.setNextDue(baseDate.plusDays(request.getCycleDays()));
-        }
+        LocalDate baseDate = (request.getStartDate() != null)
+                ? request.getStartDate()
+                : (chore.getStartDate() != null ? chore.getStartDate() : LocalDate.now()); // null일 경우 오늘 날짜
 
+        chore.setStartDate(baseDate); // null일 경우를 포함해 startDate 설정
+
+        if (chore.getCycleDays() != null) {
+            if (baseDate.isBefore(LocalDate.now())) { // 시작일이 과거인 경우 startDate + cycleDays
+                chore.setNextDue(baseDate.plusDays(chore.getCycleDays()));
+            } else { // 시작일이 오늘 이후인 경우 startDate
+                chore.setNextDue(baseDate);
+            }
+        }
 
         return choreRepository.save(chore);
     }
@@ -55,5 +67,53 @@ public class ChoreService {
                 ))
                 .collect(Collectors.toList());
     }
+
+    public Chore editChore(Long choreId, ChoreEditRequest request) {
+        Chore chore = choreRepository.findById(choreId)
+                .orElseThrow(() -> new EntityNotFoundException("Chore not found"));
+
+        if (request.getTitle() != null) {
+            chore.setTitle(request.getTitle());
+        }
+        if (request.getCycleDays() != null) {
+            chore.setCycleDays(request.getCycleDays());
+        }
+        if (request.getStartDate() != null) {
+            chore.setStartDate(request.getStartDate());
+        }
+        if (request.getReminderEnabled() != null) {
+            chore.setReminderEnabled(request.getReminderEnabled());
+        }
+        if (request.getReminderDays() != null) {
+            chore.setReminderDays(request.getReminderDays());
+        }
+
+        if (request.getStartDate() != null) {
+            chore.setStartDate(request.getStartDate());
+        } else if (chore.getStartDate() == null) {
+            chore.setStartDate(LocalDate.now());
+        }
+
+        if (request.getCycleDays() != null) {
+            chore.setCycleDays(request.getCycleDays());
+        }
+
+        // nextDue 재계산 (cycleDays 변경 시 or startDate 변경 시)
+        LocalDate baseDate = (request.getStartDate() != null)
+                ? request.getStartDate()
+                : chore.getStartDate();
+
+        if (chore.getCycleDays() != null) {
+            if (baseDate.isBefore(LocalDate.now())) { // 시작일이 과거인 경우 startDate + cycleDays
+                chore.setNextDue(baseDate.plusDays(chore.getCycleDays()));
+            } else { // 시작일이 오늘 이후인 경우 startDate
+                chore.setNextDue(baseDate);
+            }
+        }
+
+
+        return choreRepository.save(chore);
+    }
+
 
 }


### PR DESCRIPTION
## 🔍 Overview

Implement the ability to **edit** and **delete** chores.  
This includes updating chore attributes and deleting them by ID.

## ✨ Changes

- Implement `PATCH /api/chores/{id}` for chore editing  
- Implement `DELETE /api/chores/{id}` for chore deletion  
- Add logic to calculate `nextDue` date based on `startDate` and `cycleDays`  
- Add fallback logic to use `LocalDate.now()` when `startDate` is null

## 📸 Screenshots

N/A (backend only)

## 🔗 Related Task
[Implement Chore edit API](https://home-protectors.atlassian.net/browse/HOME-46?atlOrigin=eyJpIjoiNWE3MTQyNzI0MDcwNDVkYjljNzQwMjM0ZTI0YTgxNGQiLCJwIjoiaiJ9)
[Implement Chore delete API](https://home-protectors.atlassian.net/browse/HOME-45?atlOrigin=eyJpIjoiYTE2Mzc2NTMyY2VjNGNmNWI3MGMzNjRlMTkxZjUyYTUiLCJwIjoiaiJ9)

## 💬 Additional Notes

- Authorization based on group ownership (via JWT) to be implemented later (`TODO` marked)  
- Consider soft delete for future data preservation
