### PR TITLE
prevent past dates and add reminder logic

### DIFF
--- a/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
+++ b/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
@@ -33,8 +33,10 @@ public class ChoreController {
                 chore.getTitle(),
                 chore.getStartDate(),
                 chore.getCycleDays(),
+                chore.getNextDue(),
                 chore.getReminderEnabled(),
-                chore.getReminderDays()
+                chore.getReminderDays(),
+                chore.getReminderDate()
         );
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -61,8 +63,10 @@ public class ChoreController {
                 updated.getTitle(),
                 updated.getStartDate(),
                 updated.getCycleDays(),
+                updated.getNextDue(),
                 updated.getReminderEnabled(),
-                updated.getReminderDays()
+                updated.getReminderDays(),
+                updated.getReminderDate()
         );
 
         return ResponseEntity.ok(new ResponseDTO<>(true, "Chore updated successfully", response));

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCreateRequest.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCreateRequest.java
@@ -23,6 +23,7 @@ public class ChoreCreateRequest {
     @Max(value = 365, message = "반복 주기는 365일 이하여야 합니다.")
     private Integer cycleDays;
 
+    @FutureOrPresent(message = "시작일은 오늘 이후여야 합니다.")
     private LocalDate startDate;
 
     private Boolean reminderEnabled;

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCreateResponse.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCreateResponse.java
@@ -17,6 +17,8 @@ public class ChoreCreateResponse {
     private String title;
     private LocalDate startDate;
     private Integer cycleDays;
+    private LocalDate NextDue;
     private Boolean reminderEnabled;
     private Integer reminderDays;
+    private LocalDate reminderDate;
 }

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreListItemResponse.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreListItemResponse.java
@@ -3,6 +3,7 @@ package com.homeprotectors.backend.dto.chore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
@@ -27,4 +28,10 @@ public class ChoreListItemResponse {
 
     @Schema(description = "enable reminder option")
     private Boolean reminderEnabled;
+
+    @Schema(description = "days before due date to trigger reminder")
+    private Integer reminderDays;
+
+    @Schema(description = "next reminder date")
+    private LocalDate reminderDate;
 }

--- a/src/main/java/com/homeprotectors/backend/service/ChoreService.java
+++ b/src/main/java/com/homeprotectors/backend/service/ChoreService.java
@@ -51,6 +51,13 @@ public class ChoreService {
             }
         }
 
+        // reminderDate 계산
+        if (chore.getReminderDays() != null) {
+            LocalDate calculatedReminderDate = chore.getNextDue().minusDays(chore.getReminderDays());
+            // reminderDate가 오늘 이전인 경우 오늘로 설정
+            chore.setReminderDate(calculatedReminderDate.isBefore(LocalDate.now()) ? LocalDate.now() : calculatedReminderDate);
+        }
+
         return choreRepository.save(chore);
     }
 
@@ -64,7 +71,9 @@ public class ChoreService {
                         c.getTitle(),
                         c.getCycleDays(),
                         c.getNextDue(),
-                        c.getReminderEnabled()
+                        c.getReminderEnabled(),
+                        c.getReminderDays(),
+                        c.getReminderDate()
                 ))
                 .collect(Collectors.toList());
     }
@@ -110,6 +119,13 @@ public class ChoreService {
             } else { // 시작일이 오늘 이후인 경우 startDate
                 chore.setNextDue(baseDate);
             }
+        }
+
+        // reminderDate 재계산 (reminderDays 변경 시)
+        if (chore.getReminderDays() != null) {
+            LocalDate calculatedReminderDate = chore.getNextDue().minusDays(chore.getReminderDays());
+            // reminderDate가 오늘 이전인 경우 오늘로 설정
+            chore.setReminderDate(calculatedReminderDate.isBefore(LocalDate.now()) ? LocalDate.now() : calculatedReminderDate);
         }
 
 

--- a/src/main/java/com/homeprotectors/backend/service/ChoreService.java
+++ b/src/main/java/com/homeprotectors/backend/service/ChoreService.java
@@ -36,20 +36,12 @@ public class ChoreService {
         chore.setCreatedBy(1L); // TODO: 임시 user ID. 나중에 JWT 인증 적용해서 동적으로 변경
         chore.setCreatedAt(LocalDateTime.now());
 
-        // nextDue 계산
-        LocalDate baseDate = (request.getStartDate() != null)
-                ? request.getStartDate()
-                : (chore.getStartDate() != null ? chore.getStartDate() : LocalDate.now()); // null일 경우 오늘 날짜
+        // 시작일이 null인 경우 오늘로 설정
+        LocalDate startDate = (request.getStartDate() != null) ? request.getStartDate() : LocalDate.now();
+        chore.setStartDate(startDate);
 
-        chore.setStartDate(baseDate); // null일 경우를 포함해 startDate 설정
-
-        if (chore.getCycleDays() != null) {
-            if (baseDate.isBefore(LocalDate.now())) { // 시작일이 과거인 경우 startDate + cycleDays
-                chore.setNextDue(baseDate.plusDays(chore.getCycleDays()));
-            } else { // 시작일이 오늘 이후인 경우 startDate
-                chore.setNextDue(baseDate);
-            }
-        }
+        // chore 생성 시 nextDue는 시작일로 설정
+        chore.setNextDue(startDate);
 
         // reminderDate 계산
         if (chore.getReminderDays() != null) {
@@ -108,18 +100,12 @@ public class ChoreService {
             chore.setCycleDays(request.getCycleDays());
         }
 
-        // nextDue 재계산 (cycleDays 변경 시 or startDate 변경 시)
-        LocalDate baseDate = (request.getStartDate() != null)
-                ? request.getStartDate()
-                : chore.getStartDate();
+        // 시작일이 null인 경우 오늘로 설정
+        LocalDate startDate = (chore.getStartDate() != null) ? chore.getStartDate() : LocalDate.now();
+        chore.setStartDate(startDate);
 
-        if (chore.getCycleDays() != null) {
-            if (baseDate.isBefore(LocalDate.now())) { // 시작일이 과거인 경우 startDate + cycleDays
-                chore.setNextDue(baseDate.plusDays(chore.getCycleDays()));
-            } else { // 시작일이 오늘 이후인 경우 startDate
-                chore.setNextDue(baseDate);
-            }
-        }
+        // chore 수정 시 nextDue는 시작일로 설정
+        chore.setNextDue(startDate);
 
         // reminderDate 재계산 (reminderDays 변경 시)
         if (chore.getReminderDays() != null) {


### PR DESCRIPTION
### 🔍 Overview

This PR includes enhancements to Chore creation and update logic.  
`startDate` and `nextDue` are not unintentionally set to past dates and to centralize the calculation logic for `reminderDate`.

---

### ✨ Changes

- Prevented `startDate` and `nextDue` from being set to past dates during creation
- Added centralized `reminderDate` calculation method inside the Chore service
- Updated both creation and update flow to apply the reminder logic

---

### 🔗 Related Tasks
-

---

### 💬 Additional Notes

