### PR TITLE
✨feat: implement chore completion API with Chore history entity

### DIFF
--- a/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
+++ b/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
@@ -1,9 +1,6 @@
 package com.homeprotectors.backend.controller;
 
-import com.homeprotectors.backend.dto.chore.ChoreCreateRequest;
-import com.homeprotectors.backend.dto.chore.ChoreCreateResponse;
-import com.homeprotectors.backend.dto.chore.ChoreEditRequest;
-import com.homeprotectors.backend.dto.chore.ChoreListItemResponse;
+import com.homeprotectors.backend.dto.chore.*;
 import com.homeprotectors.backend.dto.common.ResponseDTO;
 import com.homeprotectors.backend.entity.Chore;
 import com.homeprotectors.backend.service.ChoreService;
@@ -78,6 +75,16 @@ public class ChoreController {
         choreService.deleteChore(choreId);
         return ResponseEntity.noContent().build(); // 204 No Content
     }
+
+    @Operation(summary = "chore 완료", description = "Mark a chore as completed and update the next due date")
+    @PostMapping("/complete")
+    public ResponseEntity<ResponseDTO<ChoreCompleteResponse>> completeChore(
+            @Valid @RequestBody ChoreCompleteRequest request) {
+        ChoreCompleteResponse response = choreService.completeChore(request);
+        return ResponseEntity.ok(new ResponseDTO<>(true, "Chore completed successfully", response));
+    }
+
+
 
 
 

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCompleteRequest.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCompleteRequest.java
@@ -1,0 +1,23 @@
+package com.homeprotectors.backend.dto.chore;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Chore 완료할 때 전달하는 데이터")
+public class ChoreCompleteRequest {
+
+    @NotNull
+    private Long choreId;
+
+    @NotNull
+    @Schema(description = "완료 날짜. Main View에서는 현재 날짜, Detail View에서는 사용자가 선택한 날짜 입력")
+    private LocalDate doneDate;
+}

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCompleteResponse.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCompleteResponse.java
@@ -1,0 +1,18 @@
+package com.homeprotectors.backend.dto.chore;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+public class ChoreCompleteResponse {
+    private Long id;
+    private Long groupId;
+    private String title;
+    private LocalDate scheduledDate;
+    private LocalDate newNextDue;
+    private LocalDate newReminderDate;
+    private Long doneBy;
+}

--- a/src/main/java/com/homeprotectors/backend/entity/ChoreHistory.java
+++ b/src/main/java/com/homeprotectors/backend/entity/ChoreHistory.java
@@ -1,6 +1,7 @@
 package com.homeprotectors.backend.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,7 +32,10 @@ public class ChoreHistory {
 
     private LocalDate doneDate;       // 실제 완료한 날짜 (완료한 경우만)
 
-    private Boolean isDone = false;   // 완료 여부
+    private Boolean isDone = false;
+
+    @Column(nullable = false)
+    private Long doneBy; // 완료한 사람
 
     @Column(nullable = false)
     private LocalDateTime createdAt = LocalDateTime.now();

--- a/src/main/java/com/homeprotectors/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/homeprotectors/backend/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.annotation.*;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -19,5 +20,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .badRequest()
                 .body(new ResponseDTO<>(false, errorMessage, null));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ResponseDTO<Object>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        return ResponseEntity
+                .badRequest()
+                .body(new ResponseDTO<>(false, ex.getMessage(), null));
     }
 }

--- a/src/main/java/com/homeprotectors/backend/repository/ChoreHistoryRepository.java
+++ b/src/main/java/com/homeprotectors/backend/repository/ChoreHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.homeprotectors.backend.repository;
+
+import com.homeprotectors.backend.entity.ChoreHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChoreHistoryRepository extends JpaRepository<ChoreHistory, Long> {
+    List<ChoreHistory> findByChoreId(Long choreId);
+}

--- a/src/main/java/com/homeprotectors/backend/service/ChoreService.java
+++ b/src/main/java/com/homeprotectors/backend/service/ChoreService.java
@@ -1,9 +1,9 @@
 package com.homeprotectors.backend.service;
 
-import com.homeprotectors.backend.dto.chore.ChoreCreateRequest;
-import com.homeprotectors.backend.dto.chore.ChoreEditRequest;
-import com.homeprotectors.backend.dto.chore.ChoreListItemResponse;
+import com.homeprotectors.backend.dto.chore.*;
 import com.homeprotectors.backend.entity.Chore;
+import com.homeprotectors.backend.entity.ChoreHistory;
+import com.homeprotectors.backend.repository.ChoreHistoryRepository;
 import com.homeprotectors.backend.repository.ChoreRepository;
 import com.homeprotectors.backend.repository.GroupRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -25,6 +26,7 @@ public class ChoreService {
 
     private final ChoreRepository choreRepository;
     private final GroupRepository groupRepository; // TODO: 그룹 기능 추후 추가
+    private final ChoreHistoryRepository choreHistoryRepository;
 
     public Chore createChore(@Valid ChoreCreateRequest request) {
         Chore chore = new Chore();
@@ -126,6 +128,59 @@ public class ChoreService {
         choreRepository.delete(chore);
     }
 
+    public ChoreCompleteResponse completeChore(@Valid ChoreCompleteRequest request) {
+        Chore chore = choreRepository.findById(request.getChoreId())
+                .orElseThrow(() -> new EntityNotFoundException("Chore not found"));
+
+        LocalDate doneDate = request.getDoneDate();
+        LocalDate today = LocalDate.now();
+
+        // 2주 이전 또는 미래 완료는 허용하지 않음
+        if (doneDate.isBefore(today.minusDays(14)) || doneDate.isAfter(today)) {
+            throw new IllegalArgumentException("완료 날짜는 오늘로부터 과거 14일 이내여야 합니다.");
+        }
+
+        // 히스토리 기록
+        ChoreHistory history = new ChoreHistory();
+        history.setChore(chore);
+        history.setDoneDate(doneDate);
+        history.setIsDone(true);
+        history.setDoneBy(1L); // TODO: JWT 적용 후 대체
+        history.setCreatedAt(LocalDateTime.now());
+
+        // scheduledDate는 기존 nextDue로 설정
+        history.setScheduledDate(chore.getNextDue());
+
+        // nextDue & reminderDate 갱신: doneDate가 가장 최근일 때만
+        if (chore.getLastDone() == null || doneDate.isAfter(chore.getLastDone())) {
+            chore.setLastDone(doneDate);
+
+            // nextDue 갱신 시 nextDue가 오늘보다 이전이면 오늘로 설정
+            LocalDate newNextDue = doneDate.plusDays(chore.getCycleDays());
+            chore.setNextDue(newNextDue.isBefore(today) ? today : newNextDue);
+
+            // reminderDate 갱신
+            if (chore.getReminderDays() != null) {
+                LocalDate newReminderDate = newNextDue.minusDays(chore.getReminderDays());
+                chore.setReminderDate(newReminderDate.isBefore(today) ? today : newReminderDate);
+            } else {
+                chore.setReminderDate(null);
+            }
+        }
+
+        choreHistoryRepository.save(history);
+        choreRepository.save(chore);
+
+        return new ChoreCompleteResponse(
+                chore.getId(),
+                chore.getGroupId(),
+                chore.getTitle(),
+                history.getScheduledDate(),
+                chore.getNextDue(),
+                chore.getReminderDate(),
+                1L // TODO: JWT 적용 후 대체
+        );
+    }
 
 
 }


### PR DESCRIPTION
## 🔍 Overview

Implements the API for marking a Chore as completed.  

## ✨ Changes

- Added POST `/api/chores/complete` endpoint
- Updated `ChoreService` to support completion logic
- Added `ChoreCompleteRequest` and `ChoreCompleteResponse` DTOs
- Saves `ChoreHistory` for each completed task
- Recalculates `nextDue`, `reminderDate`, and `lastDone` based on logic
- Rejects completion for dates more than 14 days in the past or future

## 📸 Screenshots

N/A (Backend only)

## 🔗 Related Task

- [Chore Completion API](https://home-protectors.atlassian.net/browse/HOME-49?atlOrigin=eyJpIjoiMTk5NDkyNzM3ZmM1NDRhYmI2NTg5Yzg2ZWUwOTEzZTEiLCJwIjoiaiJ9)

## 💬 Additional Notes

- JWT authentication is not applied yet; user ID is hardcoded to `1L`
- If the completed date is earlier than `lastDone`, it does not update future scheduling
- If the new schedule dates are earlier than today, it updates future scheduling as today
