### PR TITLE
✨feat: implement chore completion deletion API

### DIFF
--- a/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
+++ b/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
@@ -85,7 +85,12 @@ public class ChoreController {
     }
 
 
-
-
+    @Operation(summary = "chore 완료 취소", description = "Undo the completion of a chore")
+    @PostMapping("/undo")
+    public ResponseEntity<ResponseDTO<ChoreUndoResponse>> undoChoreCompletion(
+            @Valid @RequestBody ChoreUndoRequest request) {
+        ChoreUndoResponse response = choreService.undoChoreCompletion(request);
+        return ResponseEntity.ok(new ResponseDTO<>(true, "Chore completion undone successfully", response));
+    }
 
 }

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreUndoRequest.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreUndoRequest.java
@@ -1,0 +1,24 @@
+package com.homeprotectors.backend.dto.chore;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Chore 완료 취소할 때 전달하는 데이터")
+public class ChoreUndoRequest {
+
+    @NotNull(message = "choreId는 필수입니다.")
+    private Long choreId;
+
+    @NotNull(message = "doneDate는 필수입니다.")
+    @PastOrPresent(message = "미래 날짜는 허용되지 않습니다.")
+    private LocalDate doneDate;
+}

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreUndoResponse.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreUndoResponse.java
@@ -1,0 +1,20 @@
+package com.homeprotectors.backend.dto.chore;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "Chore 완료 취소 API의 응답 데이터")
+public class ChoreUndoResponse {
+    private Long choreId;
+    private LocalDate nextDue;
+    private LocalDate reminderDate;
+    private LocalDate lastDone;
+}

--- a/src/main/java/com/homeprotectors/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/homeprotectors/backend/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.homeprotectors.backend.exception;
 
 import com.homeprotectors.backend.dto.common.ResponseDTO;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,6 +27,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ResponseDTO<Object>> handleIllegalArgumentException(IllegalArgumentException ex) {
         return ResponseEntity
                 .badRequest()
+                .body(new ResponseDTO<>(false, ex.getMessage(), null));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ResponseDTO<Object>> handleEntityNotFoundException(EntityNotFoundException ex) {
+        return ResponseEntity
+                .status(404)
                 .body(new ResponseDTO<>(false, ex.getMessage(), null));
     }
 }

--- a/src/main/java/com/homeprotectors/backend/repository/ChoreHistoryRepository.java
+++ b/src/main/java/com/homeprotectors/backend/repository/ChoreHistoryRepository.java
@@ -4,9 +4,14 @@ import com.homeprotectors.backend.entity.ChoreHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChoreHistoryRepository extends JpaRepository<ChoreHistory, Long> {
     List<ChoreHistory> findByChoreId(Long choreId);
+    Optional<ChoreHistory> findByChoreIdAndDoneDate(Long choreId, LocalDate doneDate);
+    Optional<ChoreHistory> findTopByChoreIdAndIsDoneTrueOrderByDoneDateDesc(Long choreId);
+
 }


### PR DESCRIPTION
## 🔍 Overview  
Adds an API to undo a completed chore by removing a `ChoreHistory` record and reverting chore fields if necessary.

## ✨ Changes  
- Added `DELETE /api/chores/complete` endpoint  
- Implemented logic to delete history and restore `nextDue`, `reminderDate`, and `lastDone`  
- Added `ChoreUndoRequest` and `ChoreUndoResponse` DTO  

## 🔗 Related Task  
- [Jira](https://home-protectors.atlassian.net/browse/HOME-55?atlOrigin=eyJpIjoiNzU4ZmI3YWY0Zjg3NGEzMjg4NzM3MWM2NzRhNmVhYWYiLCJwIjoiaiJ9)

## 💬 Notes  
- Only completion records within the past 14 days can be undone  
- Reverts `nextDue` and `reminderDate` only if the removed history is the latest 
- If the history record does not exist, input null