### PR TITLE
✨feat: implement GET chore history list API and remove is_done field

### DIFF
--- a/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
+++ b/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
@@ -6,6 +6,7 @@ import com.homeprotectors.backend.entity.Chore;
 import com.homeprotectors.backend.service.ChoreService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -90,5 +91,12 @@ public class ChoreController {
         ChoreUndoResponse response = choreService.undoChoreCompletion(request);
         return ResponseEntity.ok(new ResponseDTO<>(true, "Chore completion undone successfully", response));
     }
+
+    @Operation(summary = "chore history 조회", description = "Retrieve history records of a specific chore by ID")
+    @GetMapping("/{choreId}/history")
+    public ResponseDTO<List<ChoreHistoryItemResponse>> getChoreHistory(@PathVariable Long choreId) {
+        List<ChoreHistoryItemResponse> history = choreService.getChoreHistory(choreId);
+        return new ResponseDTO<>(true, "Chore history retrieved", history);
+        }
 
 }

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreHistoryItemResponse.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreHistoryItemResponse.java
@@ -1,0 +1,18 @@
+package com.homeprotectors.backend.dto.chore;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChoreHistoryItemResponse {
+
+    private Long id;
+    private LocalDate scheduledDate;
+    private LocalDate doneDate;
+    private Long doneBy;
+}

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreHistoryItemResponse.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreHistoryItemResponse.java
@@ -5,14 +5,23 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class ChoreHistoryItemResponse {
 
-    private Long id;
-    private LocalDate scheduledDate;
-    private LocalDate doneDate;
-    private Long doneBy;
+    private Long choreId;
+    private LocalDate nextDue;
+    private List<ChoreHistoryListResponse> history;
+
+    @Data
+    @AllArgsConstructor
+    public static class ChoreHistoryListResponse {
+        private Long id;
+        private LocalDate doneDate;
+        private Long doneBy;
+    }
+
 }

--- a/src/main/java/com/homeprotectors/backend/entity/ChoreHistory.java
+++ b/src/main/java/com/homeprotectors/backend/entity/ChoreHistory.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import jakarta.persistence.Id;
+import org.hibernate.validator.constraints.UniqueElements;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/com/homeprotectors/backend/entity/ChoreHistory.java
+++ b/src/main/java/com/homeprotectors/backend/entity/ChoreHistory.java
@@ -32,8 +32,6 @@ public class ChoreHistory {
 
     private LocalDate doneDate;       // 실제 완료한 날짜 (완료한 경우만)
 
-    private Boolean isDone = false;
-
     @Column(nullable = false)
     private Long doneBy; // 완료한 사람
 

--- a/src/main/java/com/homeprotectors/backend/repository/ChoreHistoryRepository.java
+++ b/src/main/java/com/homeprotectors/backend/repository/ChoreHistoryRepository.java
@@ -13,4 +13,6 @@ public interface ChoreHistoryRepository extends JpaRepository<ChoreHistory, Long
     List<ChoreHistory> findByChoreId(Long choreId);
     Optional<ChoreHistory> findByChoreIdAndDoneDate(Long choreId, LocalDate doneDate);
     Optional<ChoreHistory> findTopByChoreIdOrderByDoneDateDesc(Long choreId);
+    List<ChoreHistory> findByChoreIdOrderByDoneDateDesc(Long choreId);
+    boolean existsByChoreIdAndDoneDate(Long id, LocalDate doneDate);
 }

--- a/src/main/java/com/homeprotectors/backend/repository/ChoreHistoryRepository.java
+++ b/src/main/java/com/homeprotectors/backend/repository/ChoreHistoryRepository.java
@@ -12,6 +12,5 @@ import java.util.Optional;
 public interface ChoreHistoryRepository extends JpaRepository<ChoreHistory, Long> {
     List<ChoreHistory> findByChoreId(Long choreId);
     Optional<ChoreHistory> findByChoreIdAndDoneDate(Long choreId, LocalDate doneDate);
-    Optional<ChoreHistory> findTopByChoreIdAndIsDoneTrueOrderByDoneDateDesc(Long choreId);
-
+    Optional<ChoreHistory> findTopByChoreIdOrderByDoneDateDesc(Long choreId);
 }

--- a/src/main/java/com/homeprotectors/backend/service/ChoreService.java
+++ b/src/main/java/com/homeprotectors/backend/service/ChoreService.java
@@ -139,7 +139,6 @@ public class ChoreService {
         ChoreHistory history = new ChoreHistory();
         history.setChore(chore);
         history.setDoneDate(doneDate);
-        history.setIsDone(true);
         history.setDoneBy(1L); // TODO: JWT 적용 후 대체
         history.setCreatedAt(LocalDateTime.now());
 
@@ -200,7 +199,7 @@ public class ChoreService {
         if (chore.getLastDone() != null && chore.getLastDone().equals(request.getDoneDate())) {
             // 남아 있는 히스토리 중 가장 최근 doneDate 찾기
             Optional<ChoreHistory> latestHistoryOpt = choreHistoryRepository
-                    .findTopByChoreIdAndIsDoneTrueOrderByDoneDateDesc(chore.getId());
+                    .findTopByChoreIdOrderByDoneDateDesc(chore.getId());
 
             if (latestHistoryOpt.isPresent()) {
                 LocalDate latestDoneDate = latestHistoryOpt.get().getDoneDate();
@@ -231,6 +230,23 @@ public class ChoreService {
                 chore.getReminderDate(),
                 chore.getLastDone()
         );
+    }
+
+    public List<ChoreHistoryItemResponse> getChoreHistory(Long choreId) {
+        List<ChoreHistory> histories = choreHistoryRepository.findByChoreId(choreId);
+        if (histories.isEmpty()) {
+            throw new EntityNotFoundException("해당 Chore의 히스토리가 없습니다.");
+        }
+
+        return histories.stream()
+                .map(history -> new ChoreHistoryItemResponse(
+                        history.getId(),
+                        history.getDoneDate(),
+                        history.getScheduledDate(),
+                        history.getDoneBy()
+                ))
+                .collect(Collectors.toList());
+
     }
 
 


### PR DESCRIPTION
## 🔍 Overview
Implement retrieve chore history list API and remove is_done field from chore_history table.
Now a chore history record directly implies chore completion.

## ✨ Changes
- Added endpoint `GET /api/chore/{choreId}/history
- Removed isDone field from from choreHistory entity
- Updated repository and service logic accordingly
- Add an unique validation check for duplicate doneDate records

## 🔗 Related Task
- [JIRA](https://home-protectors.atlassian.net/browse/HOME-48?atlOrigin=eyJpIjoiZGU5MDVmY2ZkODBiNGI4NTk1ODJmYjMzM2NiODE1N2IiLCJwIjoiaiJ9)

## 💬 Additional Notes
- Need to check if any other response field is required from FE
  - scheduledDate removed, nextDue added
- The history records are retrieved in descending order by doneDate