### PR TITLE
✨feat: allow null return and remove list in Chore history response

### DIFF
--- a/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
+++ b/src/main/java/com/homeprotectors/backend/controller/ChoreController.java
@@ -94,9 +94,12 @@ public class ChoreController {
 
     @Operation(summary = "chore history 조회", description = "Retrieve history records of a specific chore by ID")
     @GetMapping("/{choreId}/history")
-    public ResponseDTO<List<ChoreHistoryItemResponse>> getChoreHistory(@PathVariable Long choreId) {
-        List<ChoreHistoryItemResponse> history = choreService.getChoreHistory(choreId);
-        return new ResponseDTO<>(true, "Chore history retrieved", history);
+    public ResponseDTO<ChoreHistoryItemResponse> getChoreHistory(@PathVariable Long choreId) {
+        ChoreHistoryItemResponse history = choreService.getChoreHistory(choreId);
+        if (history.getHistory().isEmpty()) {
+            return new ResponseDTO<>(true, "No history records found for this chore", history);
         }
+        return new ResponseDTO<>(true, "Chore history retrieved", history);
+    }
 
 }


### PR DESCRIPTION
## 🔍 Overview
Allow for a null history record and remove the list map from the chore history response.

## ✨ Changes
- Allowed to return a history list regardless of whether history is empty
- Removed the outermost list from the chore history list response

## 🔗 Related Task
<!-- Link to relevant Jira ticket(s) -->

- [JIRA](https://home-protectors.atlassian.net/browse/HOME-82?atlOrigin=eyJpIjoiOGZlNTAyYTRjY2I4NDVjOThlZmNmZWU5N2Y1ZTY3MTUiLCJwIjoiaiJ9)
