### PR TITLE
feat: add scheduled push notification flow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
+	implementation 'com.google.firebase:firebase-admin:9.7.0'
 
 }
 

--- a/sql/20260327_create_push_notification_tables.sql
+++ b/sql/20260327_create_push_notification_tables.sql
@@ -1,0 +1,72 @@
+-- Push notification tables for production PostgreSQL.
+-- Safe to re-run on an environment where the tables may already exist.
+
+CREATE TABLE IF NOT EXISTS device_tokens (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    platform VARCHAR(20) NOT NULL,
+    push_token VARCHAR(512) NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    last_seen_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT chk_device_tokens_platform
+        CHECK (platform IN ('IOS', 'ANDROID'))
+);
+
+CREATE TABLE IF NOT EXISTS notification_delivery_logs (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    notification_type VARCHAR(50) NOT NULL,
+    delivery_date DATE NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    title VARCHAR(120),
+    body VARCHAR(255),
+    error_message VARCHAR(1000),
+    created_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT chk_notification_delivery_logs_type
+        CHECK (notification_type IN ('DAILY_CHORE_REMINDER')),
+    CONSTRAINT chk_notification_delivery_logs_status
+        CHECK (status IN ('SENT', 'SKIPPED', 'FAILED'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_device_tokens_push_token
+    ON device_tokens (push_token);
+
+CREATE INDEX IF NOT EXISTS idx_device_tokens_user_enabled
+    ON device_tokens (user_id, enabled);
+
+CREATE INDEX IF NOT EXISTS idx_device_tokens_last_seen
+    ON device_tokens (last_seen_at);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_notification_delivery_once_per_day
+    ON notification_delivery_logs (user_id, notification_type, delivery_date);
+
+CREATE INDEX IF NOT EXISTS idx_notification_delivery_lookup
+    ON notification_delivery_logs (user_id, notification_type, delivery_date);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_device_tokens_user_id'
+    ) THEN
+        ALTER TABLE device_tokens
+            ADD CONSTRAINT fk_device_tokens_user_id
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_notification_delivery_logs_user_id'
+    ) THEN
+        ALTER TABLE notification_delivery_logs
+            ADD CONSTRAINT fk_notification_delivery_logs_user_id
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+    END IF;
+END $$;

--- a/src/main/java/com/homeprotectors/backend/config/FirebaseConfig.java
+++ b/src/main/java/com/homeprotectors/backend/config/FirebaseConfig.java
@@ -1,0 +1,53 @@
+package com.homeprotectors.backend.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Bean
+    @ConditionalOnProperty(prefix = "app.push", name = "enabled", havingValue = "true")
+    public FirebaseApp firebaseApp(
+            @Value("${app.push.fcm.credentials-path:}") String credentialsPath,
+            @Value("${app.push.fcm.project-id:}") String projectId
+    ) throws IOException {
+        if (!FirebaseApp.getApps().isEmpty()) {
+            return FirebaseApp.getInstance();
+        }
+
+        FirebaseOptions.Builder builder = FirebaseOptions.builder();
+
+        // When a service account file path is provided, load it directly.
+        // Otherwise fall back to application default credentials.
+        if (credentialsPath != null && !credentialsPath.isBlank()) {
+            try (InputStream inputStream = new FileInputStream(credentialsPath)) {
+                builder.setCredentials(GoogleCredentials.fromStream(inputStream));
+            }
+        } else {
+            builder.setCredentials(GoogleCredentials.getApplicationDefault());
+        }
+
+        if (projectId != null && !projectId.isBlank()) {
+            builder.setProjectId(projectId);
+        }
+
+        return FirebaseApp.initializeApp(builder.build());
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "app.push", name = "enabled", havingValue = "true")
+    public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+        return FirebaseMessaging.getInstance(firebaseApp);
+    }
+}

--- a/src/main/java/com/homeprotectors/backend/config/PushNotificationConfig.java
+++ b/src/main/java/com/homeprotectors/backend/config/PushNotificationConfig.java
@@ -1,0 +1,23 @@
+package com.homeprotectors.backend.config;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.homeprotectors.backend.service.DisabledPushNotificationService;
+import com.homeprotectors.backend.service.FcmPushNotificationService;
+import com.homeprotectors.backend.service.PushNotificationService;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PushNotificationConfig {
+
+    @Bean
+    public PushNotificationService pushNotificationService(ObjectProvider<FirebaseMessaging> firebaseMessagingProvider) {
+        FirebaseMessaging firebaseMessaging = firebaseMessagingProvider.getIfAvailable();
+        if (firebaseMessaging != null) {
+            return new FcmPushNotificationService(firebaseMessaging);
+        }
+
+        return new DisabledPushNotificationService();
+    }
+}

--- a/src/main/java/com/homeprotectors/backend/config/SchedulingConfig.java
+++ b/src/main/java/com/homeprotectors/backend/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.homeprotectors.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/homeprotectors/backend/controller/AdminNotificationController.java
+++ b/src/main/java/com/homeprotectors/backend/controller/AdminNotificationController.java
@@ -1,0 +1,57 @@
+package com.homeprotectors.backend.controller;
+
+import com.homeprotectors.backend.dto.common.ResponseDTO;
+import com.homeprotectors.backend.dto.notification.DailyReminderDispatchSummary;
+import com.homeprotectors.backend.exception.ApiException;
+import com.homeprotectors.backend.service.NotificationDispatchService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/notifications")
+public class AdminNotificationController {
+
+    private final NotificationDispatchService notificationDispatchService;
+
+    @Value("${app.push.manual-dispatch.enabled:false}")
+    private boolean manualDispatchEnabled;
+
+    @Value("${app.push.manual-dispatch.secret:}")
+    private String manualDispatchSecret;
+
+    @Operation(
+            summary = "수동 알림 발송",
+            description = "Immediately dispatch the daily chore reminder flow for testing"
+    )
+    @PostMapping("/daily-chore-reminder/dispatch")
+    public ResponseEntity<ResponseDTO<DailyReminderDispatchSummary>> dispatchDailyChoreReminder(
+            @RequestHeader("X-ADMIN-SECRET") String adminSecret
+    ) {
+        validateManualDispatchAccess(adminSecret);
+
+        DailyReminderDispatchSummary summary = notificationDispatchService.dispatchDailyChoreReminders();
+        return ResponseEntity.ok(new ResponseDTO<>(true, "Daily chore reminder dispatched", summary));
+    }
+
+    private void validateManualDispatchAccess(String adminSecret) {
+        // Keep this endpoint disabled by default because the project has no admin auth flow yet.
+        if (!manualDispatchEnabled) {
+            throw new ApiException("MANUAL_DISPATCH_DISABLED", "Manual dispatch endpoint is disabled.");
+        }
+
+        if (manualDispatchSecret == null || manualDispatchSecret.isBlank()) {
+            throw new ApiException("MANUAL_DISPATCH_SECRET_NOT_SET", "Manual dispatch secret is not configured.");
+        }
+
+        if (!manualDispatchSecret.equals(adminSecret)) {
+            throw new ApiException("INVALID_ADMIN_SECRET", "Invalid admin secret.");
+        }
+    }
+}

--- a/src/main/java/com/homeprotectors/backend/controller/AdminNotificationController.java
+++ b/src/main/java/com/homeprotectors/backend/controller/AdminNotificationController.java
@@ -5,6 +5,7 @@ import com.homeprotectors.backend.dto.notification.DailyReminderDispatchSummary;
 import com.homeprotectors.backend.exception.ApiException;
 import com.homeprotectors.backend.service.NotificationDispatchService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +31,7 @@ public class AdminNotificationController {
             summary = "수동 알림 발송",
             description = "Immediately dispatch the daily chore reminder flow for testing"
     )
+    @SecurityRequirements
     @PostMapping("/daily-chore-reminder/dispatch")
     public ResponseEntity<ResponseDTO<DailyReminderDispatchSummary>> dispatchDailyChoreReminder(
             @RequestHeader("X-ADMIN-SECRET") String adminSecret

--- a/src/main/java/com/homeprotectors/backend/controller/PushTokenController.java
+++ b/src/main/java/com/homeprotectors/backend/controller/PushTokenController.java
@@ -1,0 +1,48 @@
+package com.homeprotectors.backend.controller;
+
+import com.homeprotectors.backend.dto.common.ResponseDTO;
+import com.homeprotectors.backend.dto.notification.PushTokenRegisterRequest;
+import com.homeprotectors.backend.dto.notification.PushTokenResponse;
+import com.homeprotectors.backend.service.PushTokenService;
+import com.homeprotectors.backend.service.UserContextService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/push-tokens")
+public class PushTokenController {
+
+    private final PushTokenService pushTokenService;
+    private final UserContextService userContextService;
+
+    @ModelAttribute
+    public void loadCurrentUser(@RequestAttribute("currentUserId") UUID currentUserId) {
+        userContextService.requireInternalUserId(currentUserId);
+    }
+
+    @Operation(summary = "Push token 등록", description = "Register or refresh the current user's push token")
+    @PostMapping
+    public ResponseEntity<ResponseDTO<PushTokenResponse>> registerToken(
+            @Valid @RequestBody PushTokenRegisterRequest request,
+            @RequestAttribute("currentUserId") UUID currentUserId) {
+        PushTokenResponse response = pushTokenService.registerToken(request, currentUserId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new ResponseDTO<>(true, "Push token registered successfully", response));
+    }
+
+    @Operation(summary = "Push token 삭제", description = "Delete one of the current user's push tokens")
+    @DeleteMapping("/{tokenId}")
+    public ResponseEntity<Void> deleteToken(
+            @PathVariable Long tokenId,
+            @RequestAttribute("currentUserId") UUID currentUserId) {
+        pushTokenService.deleteToken(tokenId, currentUserId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/homeprotectors/backend/dto/notification/DailyChoreReminderTarget.java
+++ b/src/main/java/com/homeprotectors/backend/dto/notification/DailyChoreReminderTarget.java
@@ -1,0 +1,11 @@
+package com.homeprotectors.backend.dto.notification;
+
+import java.util.List;
+
+public record DailyChoreReminderTarget(
+        Long userId,
+        List<String> pushTokens,
+        long choreCount,
+        String title,
+        String body
+) {}

--- a/src/main/java/com/homeprotectors/backend/dto/notification/DailyReminderDispatchItem.java
+++ b/src/main/java/com/homeprotectors/backend/dto/notification/DailyReminderDispatchItem.java
@@ -1,0 +1,11 @@
+package com.homeprotectors.backend.dto.notification;
+
+import java.util.List;
+
+public record DailyReminderDispatchItem(
+        Long userId,
+        long choreCount,
+        int successCount,
+        int failureCount,
+        List<String> invalidTokens
+) {}

--- a/src/main/java/com/homeprotectors/backend/dto/notification/DailyReminderDispatchSummary.java
+++ b/src/main/java/com/homeprotectors/backend/dto/notification/DailyReminderDispatchSummary.java
@@ -1,0 +1,10 @@
+package com.homeprotectors.backend.dto.notification;
+
+import java.util.List;
+
+public record DailyReminderDispatchSummary(
+        int targetUserCount,
+        int successCount,
+        int failureCount,
+        List<DailyReminderDispatchItem> items
+) {}

--- a/src/main/java/com/homeprotectors/backend/dto/notification/PushNotificationCommand.java
+++ b/src/main/java/com/homeprotectors/backend/dto/notification/PushNotificationCommand.java
@@ -1,0 +1,11 @@
+package com.homeprotectors.backend.dto.notification;
+
+import java.util.List;
+import java.util.Map;
+
+public record PushNotificationCommand(
+        List<String> pushTokens,
+        String title,
+        String body,
+        Map<String, String> data
+) {}

--- a/src/main/java/com/homeprotectors/backend/dto/notification/PushNotificationResult.java
+++ b/src/main/java/com/homeprotectors/backend/dto/notification/PushNotificationResult.java
@@ -1,0 +1,10 @@
+package com.homeprotectors.backend.dto.notification;
+
+import java.util.List;
+
+public record PushNotificationResult(
+        int successCount,
+        int failureCount,
+        List<String> invalidTokens,
+        List<String> failedTokens
+) {}

--- a/src/main/java/com/homeprotectors/backend/dto/notification/PushTokenRegisterRequest.java
+++ b/src/main/java/com/homeprotectors/backend/dto/notification/PushTokenRegisterRequest.java
@@ -1,0 +1,13 @@
+package com.homeprotectors.backend.dto.notification;
+
+import com.homeprotectors.backend.entity.DevicePlatform;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PushTokenRegisterRequest(
+        @NotNull(message = "platform is required")
+        DevicePlatform platform,
+
+        @NotBlank(message = "pushToken is required")
+        String pushToken
+) {}

--- a/src/main/java/com/homeprotectors/backend/dto/notification/PushTokenResponse.java
+++ b/src/main/java/com/homeprotectors/backend/dto/notification/PushTokenResponse.java
@@ -1,0 +1,9 @@
+package com.homeprotectors.backend.dto.notification;
+
+import com.homeprotectors.backend.entity.DevicePlatform;
+
+public record PushTokenResponse(
+        Long id,
+        DevicePlatform platform,
+        boolean enabled
+) {}

--- a/src/main/java/com/homeprotectors/backend/entity/DevicePlatform.java
+++ b/src/main/java/com/homeprotectors/backend/entity/DevicePlatform.java
@@ -1,0 +1,6 @@
+package com.homeprotectors.backend.entity;
+
+public enum DevicePlatform {
+    IOS,
+    ANDROID
+}

--- a/src/main/java/com/homeprotectors/backend/entity/DeviceToken.java
+++ b/src/main/java/com/homeprotectors/backend/entity/DeviceToken.java
@@ -1,0 +1,65 @@
+package com.homeprotectors.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(
+        name = "device_tokens",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_device_tokens_push_token", columnNames = "push_token")
+        },
+        indexes = {
+                @Index(name = "idx_device_tokens_user_enabled", columnList = "user_id, enabled"),
+                @Index(name = "idx_device_tokens_last_seen", columnList = "last_seen_at")
+        }
+)
+@Data
+public class DeviceToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DevicePlatform platform;
+
+    @Column(name = "push_token", nullable = false, unique = true, length = 512)
+    private String pushToken;
+
+    @Column(nullable = false)
+    private Boolean enabled = true;
+
+    @Column(name = "last_seen_at", nullable = false)
+    private OffsetDateTime lastSeenAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        OffsetDateTime now = OffsetDateTime.now();
+        if (enabled == null) {
+            enabled = true;
+        }
+        if (lastSeenAt == null) {
+            lastSeenAt = now;
+        }
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = OffsetDateTime.now();
+    }
+}

--- a/src/main/java/com/homeprotectors/backend/entity/NotificationDeliveryLog.java
+++ b/src/main/java/com/homeprotectors/backend/entity/NotificationDeliveryLog.java
@@ -1,0 +1,59 @@
+package com.homeprotectors.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(
+        name = "notification_delivery_logs",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_notification_delivery_once_per_day",
+                        columnNames = {"user_id", "notification_type", "delivery_date"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_notification_delivery_lookup", columnList = "user_id, notification_type, delivery_date")
+        }
+)
+@Data
+public class NotificationDeliveryLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "notification_type", nullable = false, length = 50)
+    private NotificationType notificationType;
+
+    @Column(name = "delivery_date", nullable = false)
+    private LocalDate deliveryDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private NotificationDeliveryStatus status;
+
+    @Column(length = 120)
+    private String title;
+
+    @Column(length = 255)
+    private String body;
+
+    @Column(name = "error_message", length = 1000)
+    private String errorMessage;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    void onCreate() {
+        createdAt = OffsetDateTime.now();
+    }
+}

--- a/src/main/java/com/homeprotectors/backend/entity/NotificationDeliveryStatus.java
+++ b/src/main/java/com/homeprotectors/backend/entity/NotificationDeliveryStatus.java
@@ -1,0 +1,7 @@
+package com.homeprotectors.backend.entity;
+
+public enum NotificationDeliveryStatus {
+    SENT,
+    SKIPPED,
+    FAILED
+}

--- a/src/main/java/com/homeprotectors/backend/entity/NotificationType.java
+++ b/src/main/java/com/homeprotectors/backend/entity/NotificationType.java
@@ -1,0 +1,5 @@
+package com.homeprotectors.backend.entity;
+
+public enum NotificationType {
+    DAILY_CHORE_REMINDER
+}

--- a/src/main/java/com/homeprotectors/backend/repository/ChoreRepository.java
+++ b/src/main/java/com/homeprotectors/backend/repository/ChoreRepository.java
@@ -18,6 +18,8 @@ public interface ChoreRepository extends JpaRepository<Chore, Long> {
 
     Optional<Chore> findByIdAndGroupId(Long id, Long groupId);
 
+    long countByGroupIdAndNextDueLessThanEqual(Long groupId, LocalDate date);
+
     // 오버듀 + 이번주~다음달 범위를 한 번에 조회
     @Query("""
         select c from Chore c

--- a/src/main/java/com/homeprotectors/backend/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/homeprotectors/backend/repository/DeviceTokenRepository.java
@@ -1,0 +1,16 @@
+package com.homeprotectors.backend.repository;
+
+import com.homeprotectors.backend.entity.DeviceToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+    Optional<DeviceToken> findByPushToken(String pushToken);
+
+    List<DeviceToken> findByUserIdAndEnabledTrue(Long userId);
+
+    List<DeviceToken> findByEnabledTrueAndLastSeenAtAfter(OffsetDateTime threshold);
+}

--- a/src/main/java/com/homeprotectors/backend/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/homeprotectors/backend/repository/DeviceTokenRepository.java
@@ -10,7 +10,11 @@ import java.util.Optional;
 public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
     Optional<DeviceToken> findByPushToken(String pushToken);
 
+    Optional<DeviceToken> findByIdAndUserId(Long id, Long userId);
+
     List<DeviceToken> findByUserIdAndEnabledTrue(Long userId);
 
     List<DeviceToken> findByEnabledTrueAndLastSeenAtAfter(OffsetDateTime threshold);
+
+    List<DeviceToken> findByPushTokenIn(List<String> pushTokens);
 }

--- a/src/main/java/com/homeprotectors/backend/repository/NotificationDeliveryLogRepository.java
+++ b/src/main/java/com/homeprotectors/backend/repository/NotificationDeliveryLogRepository.java
@@ -1,0 +1,15 @@
+package com.homeprotectors.backend.repository;
+
+import com.homeprotectors.backend.entity.NotificationDeliveryLog;
+import com.homeprotectors.backend.entity.NotificationType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+
+public interface NotificationDeliveryLogRepository extends JpaRepository<NotificationDeliveryLog, Long> {
+    boolean existsByUserIdAndNotificationTypeAndDeliveryDate(
+            Long userId,
+            NotificationType notificationType,
+            LocalDate deliveryDate
+    );
+}

--- a/src/main/java/com/homeprotectors/backend/security/UserIdHeaderFilter.java
+++ b/src/main/java/com/homeprotectors/backend/security/UserIdHeaderFilter.java
@@ -27,6 +27,7 @@ public class UserIdHeaderFilter extends OncePerRequestFilter {
     // Public endpoints that should stay accessible without a user header.
     private final Set<String> publicPaths = Set.of(
             "/api/guests/register",
+            "/api/admin/notifications/daily-chore-reminder/dispatch",
             "/actuator/health"
     );
 

--- a/src/main/java/com/homeprotectors/backend/service/DailyNotificationScheduler.java
+++ b/src/main/java/com/homeprotectors/backend/service/DailyNotificationScheduler.java
@@ -1,0 +1,31 @@
+package com.homeprotectors.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "app.push", name = "enabled", havingValue = "true")
+public class DailyNotificationScheduler {
+
+    private final NotificationDispatchService notificationDispatchService;
+
+    // Run once every morning in KST and delegate the full send flow to the dispatch service.
+    @Scheduled(
+            cron = "${app.push.daily-chore-reminder.cron}",
+            zone = "${app.push.daily-chore-reminder.zone}"
+    )
+    public void dispatchDailyChoreReminders() {
+        var summary = notificationDispatchService.dispatchDailyChoreReminders();
+        log.info(
+                "Daily chore reminder dispatch finished. targetUsers={}, successCount={}, failureCount={}",
+                summary.targetUserCount(),
+                summary.successCount(),
+                summary.failureCount()
+        );
+    }
+}

--- a/src/main/java/com/homeprotectors/backend/service/DailyNotificationTargetService.java
+++ b/src/main/java/com/homeprotectors/backend/service/DailyNotificationTargetService.java
@@ -1,0 +1,95 @@
+package com.homeprotectors.backend.service;
+
+import com.homeprotectors.backend.dto.notification.DailyChoreReminderTarget;
+import com.homeprotectors.backend.entity.DeviceToken;
+import com.homeprotectors.backend.entity.NotificationType;
+import com.homeprotectors.backend.entity.User;
+import com.homeprotectors.backend.repository.ChoreRepository;
+import com.homeprotectors.backend.repository.DeviceTokenRepository;
+import com.homeprotectors.backend.repository.NotificationDeliveryLogRepository;
+import com.homeprotectors.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DailyNotificationTargetService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final NotificationType NOTIFICATION_TYPE = NotificationType.DAILY_CHORE_REMINDER;
+
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final UserRepository userRepository;
+    private final ChoreRepository choreRepository;
+    private final NotificationDeliveryLogRepository notificationDeliveryLogRepository;
+
+    public List<DailyChoreReminderTarget> getDailyChoreReminderTargets() {
+        LocalDate today = LocalDate.now(KST);
+        OffsetDateTime threshold = OffsetDateTime.now(KST).minusDays(30);
+
+        List<DeviceToken> activeTokens = deviceTokenRepository.findByEnabledTrueAndLastSeenAtAfter(threshold);
+        if (activeTokens.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, List<DeviceToken>> tokensByUserId = activeTokens.stream()
+                .collect(Collectors.groupingBy(DeviceToken::getUserId, LinkedHashMap::new, Collectors.toList()));
+
+        List<User> users = userRepository.findAllById(tokensByUserId.keySet()).stream()
+                .filter(user -> user.getGroupId() != null)
+                .sorted(Comparator.comparing(User::getId))
+                .toList();
+
+        Map<Long, Long> choreCountByGroupId = new LinkedHashMap<>();
+        List<DailyChoreReminderTarget> targets = new ArrayList<>();
+
+        for (User user : users) {
+            if (notificationDeliveryLogRepository.existsByUserIdAndNotificationTypeAndDeliveryDate(
+                    user.getId(),
+                    NOTIFICATION_TYPE,
+                    today
+            )) {
+                continue;
+            }
+
+            Long groupId = user.getGroupId();
+            long choreCount = choreCountByGroupId.computeIfAbsent(
+                    groupId,
+                    key -> choreRepository.countByGroupIdAndNextDueLessThanEqual(key, today)
+            );
+
+            if (choreCount <= 0) {
+                continue;
+            }
+
+            List<String> pushTokens = tokensByUserId.getOrDefault(user.getId(), List.of()).stream()
+                    .map(DeviceToken::getPushToken)
+                    .distinct()
+                    .toList();
+
+            if (pushTokens.isEmpty()) {
+                continue;
+            }
+
+            targets.add(new DailyChoreReminderTarget(
+                    user.getId(),
+                    pushTokens,
+                    choreCount,
+                    "오늘 할 일 알림",
+                    "오늘 할 일 " + choreCount + "건 확인하세요"
+            ));
+        }
+
+        return targets;
+    }
+}

--- a/src/main/java/com/homeprotectors/backend/service/DisabledPushNotificationService.java
+++ b/src/main/java/com/homeprotectors/backend/service/DisabledPushNotificationService.java
@@ -2,13 +2,9 @@ package com.homeprotectors.backend.service;
 
 import com.homeprotectors.backend.dto.notification.PushNotificationCommand;
 import com.homeprotectors.backend.dto.notification.PushNotificationResult;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-@Service
-@ConditionalOnMissingBean(PushNotificationService.class)
 public class DisabledPushNotificationService implements PushNotificationService {
 
     @Override

--- a/src/main/java/com/homeprotectors/backend/service/DisabledPushNotificationService.java
+++ b/src/main/java/com/homeprotectors/backend/service/DisabledPushNotificationService.java
@@ -1,0 +1,19 @@
+package com.homeprotectors.backend.service;
+
+import com.homeprotectors.backend.dto.notification.PushNotificationCommand;
+import com.homeprotectors.backend.dto.notification.PushNotificationResult;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@ConditionalOnMissingBean(PushNotificationService.class)
+public class DisabledPushNotificationService implements PushNotificationService {
+
+    @Override
+    public PushNotificationResult send(PushNotificationCommand command) {
+        List<String> failedTokens = command.pushTokens() == null ? List.of() : command.pushTokens();
+        return new PushNotificationResult(0, failedTokens.size(), List.of(), failedTokens);
+    }
+}

--- a/src/main/java/com/homeprotectors/backend/service/FcmPushNotificationService.java
+++ b/src/main/java/com/homeprotectors/backend/service/FcmPushNotificationService.java
@@ -1,0 +1,116 @@
+package com.homeprotectors.backend.service;
+
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.SendResponse;
+import com.homeprotectors.backend.dto.notification.PushNotificationCommand;
+import com.homeprotectors.backend.dto.notification.PushNotificationResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@ConditionalOnBean(FirebaseMessaging.class)
+public class FcmPushNotificationService implements PushNotificationService {
+
+    private static final int MAX_BATCH_SIZE = 500;
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    @Override
+    public PushNotificationResult send(PushNotificationCommand command) {
+        List<String> tokens = normalizeTokens(command.pushTokens());
+        if (tokens.isEmpty()) {
+            return new PushNotificationResult(0, 0, List.of(), List.of());
+        }
+
+        int successCount = 0;
+        List<String> invalidTokens = new ArrayList<>();
+        List<String> failedTokens = new ArrayList<>();
+
+        for (int start = 0; start < tokens.size(); start += MAX_BATCH_SIZE) {
+            int end = Math.min(start + MAX_BATCH_SIZE, tokens.size());
+            List<String> batchTokens = tokens.subList(start, end);
+
+            try {
+                List<Message> messages = buildMessages(batchTokens, command.title(), command.body(), command.data());
+                BatchResponse response = firebaseMessaging.sendEach(messages);
+                successCount += response.getSuccessCount();
+
+                for (int i = 0; i < response.getResponses().size(); i++) {
+                    SendResponse sendResponse = response.getResponses().get(i);
+                    String token = batchTokens.get(i);
+                    if (!sendResponse.isSuccessful()) {
+                        failedTokens.add(token);
+                        if (isInvalidToken(sendResponse.getException())) {
+                            invalidTokens.add(token);
+                        }
+                    }
+                }
+            } catch (FirebaseMessagingException e) {
+                failedTokens.addAll(batchTokens);
+            }
+        }
+
+        return new PushNotificationResult(
+                successCount,
+                failedTokens.size(),
+                distinct(invalidTokens),
+                distinct(failedTokens)
+        );
+    }
+
+    private List<Message> buildMessages(
+            List<String> tokens,
+            String title,
+            String body,
+            Map<String, String> data
+    ) {
+        List<Message> messages = new ArrayList<>(tokens.size());
+        for (String token : tokens) {
+            Message.Builder builder = Message.builder()
+                    .setToken(token)
+                    .setNotification(Notification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build());
+
+            if (data != null && !data.isEmpty()) {
+                builder.putAllData(data);
+            }
+
+            messages.add(builder.build());
+        }
+        return messages;
+    }
+
+    private List<String> normalizeTokens(List<String> pushTokens) {
+        if (pushTokens == null || pushTokens.isEmpty()) {
+            return List.of();
+        }
+
+        return pushTokens.stream()
+                .filter(token -> token != null && !token.isBlank())
+                .map(String::trim)
+                .distinct()
+                .toList();
+    }
+
+    private boolean isInvalidToken(FirebaseMessagingException exception) {
+        return exception != null && exception.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED;
+    }
+
+    private List<String> distinct(List<String> values) {
+        return new ArrayList<>(new LinkedHashSet<>(values));
+    }
+}

--- a/src/main/java/com/homeprotectors/backend/service/FcmPushNotificationService.java
+++ b/src/main/java/com/homeprotectors/backend/service/FcmPushNotificationService.java
@@ -10,17 +10,13 @@ import com.google.firebase.messaging.SendResponse;
 import com.homeprotectors.backend.dto.notification.PushNotificationCommand;
 import com.homeprotectors.backend.dto.notification.PushNotificationResult;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
-@Service
 @RequiredArgsConstructor
-@ConditionalOnBean(FirebaseMessaging.class)
 public class FcmPushNotificationService implements PushNotificationService {
 
     private static final int MAX_BATCH_SIZE = 500;

--- a/src/main/java/com/homeprotectors/backend/service/NotificationDispatchService.java
+++ b/src/main/java/com/homeprotectors/backend/service/NotificationDispatchService.java
@@ -1,0 +1,123 @@
+package com.homeprotectors.backend.service;
+
+import com.homeprotectors.backend.dto.notification.DailyChoreReminderTarget;
+import com.homeprotectors.backend.dto.notification.DailyReminderDispatchItem;
+import com.homeprotectors.backend.dto.notification.DailyReminderDispatchSummary;
+import com.homeprotectors.backend.dto.notification.PushNotificationCommand;
+import com.homeprotectors.backend.dto.notification.PushNotificationResult;
+import com.homeprotectors.backend.entity.DeviceToken;
+import com.homeprotectors.backend.entity.NotificationDeliveryLog;
+import com.homeprotectors.backend.entity.NotificationDeliveryStatus;
+import com.homeprotectors.backend.entity.NotificationType;
+import com.homeprotectors.backend.repository.DeviceTokenRepository;
+import com.homeprotectors.backend.repository.NotificationDeliveryLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationDispatchService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final DailyNotificationTargetService dailyNotificationTargetService;
+    private final PushNotificationService pushNotificationService;
+    private final NotificationDeliveryLogRepository notificationDeliveryLogRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+
+    public DailyReminderDispatchSummary dispatchDailyChoreReminders() {
+        LocalDate today = LocalDate.now(KST);
+        List<DailyChoreReminderTarget> targets = dailyNotificationTargetService.getDailyChoreReminderTargets();
+        List<DailyReminderDispatchItem> items = new ArrayList<>();
+        int successCount = 0;
+        int failureCount = 0;
+
+        for (DailyChoreReminderTarget target : targets) {
+            PushNotificationCommand command = new PushNotificationCommand(
+                    target.pushTokens(),
+                    target.title(),
+                    target.body(),
+                    Map.of(
+                            "type", NotificationType.DAILY_CHORE_REMINDER.name(),
+                            "date", today.toString(),
+                            "choreCount", String.valueOf(target.choreCount())
+                    )
+            );
+
+            PushNotificationResult result = pushNotificationService.send(command);
+            saveDeliveryLog(target, result, today);
+            disableInvalidTokens(result.invalidTokens());
+
+            successCount += result.successCount();
+            failureCount += result.failureCount();
+
+            items.add(new DailyReminderDispatchItem(
+                    target.userId(),
+                    target.choreCount(),
+                    result.successCount(),
+                    result.failureCount(),
+                    result.invalidTokens()
+            ));
+        }
+
+        return new DailyReminderDispatchSummary(
+                targets.size(),
+                successCount,
+                failureCount,
+                items
+        );
+    }
+
+    private void saveDeliveryLog(
+            DailyChoreReminderTarget target,
+            PushNotificationResult result,
+            LocalDate deliveryDate
+    ) {
+        NotificationDeliveryLog log = new NotificationDeliveryLog();
+        log.setUserId(target.userId());
+        log.setNotificationType(NotificationType.DAILY_CHORE_REMINDER);
+        log.setDeliveryDate(deliveryDate);
+        log.setStatus(result.successCount() > 0 ? NotificationDeliveryStatus.SENT : NotificationDeliveryStatus.FAILED);
+        log.setTitle(target.title());
+        log.setBody(target.body());
+        log.setErrorMessage(buildErrorMessage(result));
+        notificationDeliveryLogRepository.save(log);
+    }
+
+    private String buildErrorMessage(PushNotificationResult result) {
+        if (result.failureCount() <= 0) {
+            return null;
+        }
+
+        if (!result.invalidTokens().isEmpty()) {
+            return "Failed tokens: " + result.failureCount() + ", invalid tokens: " + result.invalidTokens().size();
+        }
+
+        return "Failed tokens: " + result.failureCount();
+    }
+
+    private void disableInvalidTokens(List<String> invalidTokens) {
+        if (invalidTokens == null || invalidTokens.isEmpty()) {
+            return;
+        }
+
+        List<DeviceToken> tokens = deviceTokenRepository.findByPushTokenIn(invalidTokens);
+        OffsetDateTime now = OffsetDateTime.now(KST);
+
+        for (DeviceToken token : tokens) {
+            token.setEnabled(false);
+            token.setUpdatedAt(now);
+        }
+
+        if (!tokens.isEmpty()) {
+            deviceTokenRepository.saveAll(tokens);
+        }
+    }
+}

--- a/src/main/java/com/homeprotectors/backend/service/PushNotificationService.java
+++ b/src/main/java/com/homeprotectors/backend/service/PushNotificationService.java
@@ -1,0 +1,8 @@
+package com.homeprotectors.backend.service;
+
+import com.homeprotectors.backend.dto.notification.PushNotificationCommand;
+import com.homeprotectors.backend.dto.notification.PushNotificationResult;
+
+public interface PushNotificationService {
+    PushNotificationResult send(PushNotificationCommand command);
+}

--- a/src/main/java/com/homeprotectors/backend/service/PushTokenService.java
+++ b/src/main/java/com/homeprotectors/backend/service/PushTokenService.java
@@ -1,0 +1,49 @@
+package com.homeprotectors.backend.service;
+
+import com.homeprotectors.backend.dto.notification.PushTokenRegisterRequest;
+import com.homeprotectors.backend.dto.notification.PushTokenResponse;
+import com.homeprotectors.backend.entity.DeviceToken;
+import com.homeprotectors.backend.repository.DeviceTokenRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PushTokenService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final UserContextService userContextService;
+
+    @Transactional
+    public PushTokenResponse registerToken(PushTokenRegisterRequest request, UUID currentUserId) {
+        Long userId = userContextService.requireInternalUserId(currentUserId);
+        String normalizedPushToken = request.pushToken().trim();
+        OffsetDateTime now = OffsetDateTime.now();
+
+        DeviceToken token = deviceTokenRepository.findByPushToken(normalizedPushToken)
+                .orElseGet(DeviceToken::new);
+
+        token.setUserId(userId);
+        token.setPlatform(request.platform());
+        token.setPushToken(normalizedPushToken);
+        token.setEnabled(true);
+        token.setLastSeenAt(now);
+
+        DeviceToken saved = deviceTokenRepository.save(token);
+        return new PushTokenResponse(saved.getId(), saved.getPlatform(), Boolean.TRUE.equals(saved.getEnabled()));
+    }
+
+    @Transactional
+    public void deleteToken(Long tokenId, UUID currentUserId) {
+        Long userId = userContextService.requireInternalUserId(currentUserId);
+        DeviceToken token = deviceTokenRepository.findByIdAndUserId(tokenId, userId)
+                .orElseThrow(() -> new EntityNotFoundException("Push token not found"));
+
+        deviceTokenRepository.delete(token);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,19 @@ logging:
     org.hibernate.SQL: INFO
     org.springframework.security: INFO
 
+app:
+  push:
+    enabled: ${APP_PUSH_ENABLED:false}
+    daily-chore-reminder:
+      cron: ${APP_PUSH_DAILY_CHORE_REMINDER_CRON:0 0 7 * * *}
+      zone: ${APP_PUSH_DAILY_CHORE_REMINDER_ZONE:Asia/Seoul}
+    manual-dispatch:
+      enabled: ${APP_PUSH_MANUAL_DISPATCH_ENABLED:false}
+      secret: ${APP_PUSH_MANUAL_DISPATCH_SECRET:}
+    fcm:
+      credentials-path: ${APP_PUSH_FCM_CREDENTIALS_PATH:}
+      project-id: ${APP_PUSH_FCM_PROJECT_ID:}
+
 # ===== local =====
 ---
 spring:

--- a/src/test/java/com/homeprotectors/backend/service/DailyNotificationTargetServiceTest.java
+++ b/src/test/java/com/homeprotectors/backend/service/DailyNotificationTargetServiceTest.java
@@ -1,0 +1,98 @@
+package com.homeprotectors.backend.service;
+
+import com.homeprotectors.backend.dto.notification.DailyChoreReminderTarget;
+import com.homeprotectors.backend.entity.DevicePlatform;
+import com.homeprotectors.backend.entity.DeviceToken;
+import com.homeprotectors.backend.entity.User;
+import com.homeprotectors.backend.repository.ChoreRepository;
+import com.homeprotectors.backend.repository.DeviceTokenRepository;
+import com.homeprotectors.backend.repository.NotificationDeliveryLogRepository;
+import com.homeprotectors.backend.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DailyNotificationTargetServiceTest {
+
+    @Mock
+    private DeviceTokenRepository deviceTokenRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ChoreRepository choreRepository;
+
+    @Mock
+    private NotificationDeliveryLogRepository notificationDeliveryLogRepository;
+
+    @InjectMocks
+    private DailyNotificationTargetService dailyNotificationTargetService;
+
+    @Test
+    void getDailyChoreReminderTargets_returnsOnlyEligibleUsers() {
+        DeviceToken token = new DeviceToken();
+        token.setId(1L);
+        token.setUserId(10L);
+        token.setPlatform(DevicePlatform.ANDROID);
+        token.setPushToken("token-1");
+        token.setEnabled(true);
+        token.setLastSeenAt(OffsetDateTime.now());
+
+        DeviceToken duplicateToken = new DeviceToken();
+        duplicateToken.setId(2L);
+        duplicateToken.setUserId(10L);
+        duplicateToken.setPlatform(DevicePlatform.ANDROID);
+        duplicateToken.setPushToken("token-1");
+        duplicateToken.setEnabled(true);
+        duplicateToken.setLastSeenAt(OffsetDateTime.now());
+
+        User eligibleUser = new User(UUID.randomUUID(), UUID.randomUUID(), 100L);
+        setUserId(eligibleUser, 10L);
+
+        User alreadySentUser = new User(UUID.randomUUID(), UUID.randomUUID(), 200L);
+        setUserId(alreadySentUser, 20L);
+
+        when(deviceTokenRepository.findByEnabledTrueAndLastSeenAtAfter(any()))
+                .thenReturn(List.of(token, duplicateToken));
+        when(userRepository.findAllById(any()))
+                .thenReturn(List.of(eligibleUser, alreadySentUser));
+        when(notificationDeliveryLogRepository.existsByUserIdAndNotificationTypeAndDeliveryDate(eq(10L), any(), any()))
+                .thenReturn(false);
+        when(notificationDeliveryLogRepository.existsByUserIdAndNotificationTypeAndDeliveryDate(eq(20L), any(), any()))
+                .thenReturn(true);
+        when(choreRepository.countByGroupIdAndNextDueLessThanEqual(eq(100L), any()))
+                .thenReturn(3L);
+
+        List<DailyChoreReminderTarget> targets = dailyNotificationTargetService.getDailyChoreReminderTargets();
+
+        assertThat(targets).hasSize(1);
+        assertThat(targets.getFirst().userId()).isEqualTo(10L);
+        assertThat(targets.getFirst().choreCount()).isEqualTo(3L);
+        assertThat(targets.getFirst().pushTokens()).containsExactly("token-1");
+        assertThat(targets.getFirst().body()).isEqualTo("오늘 할 일 3건 확인하세요");
+    }
+
+    private void setUserId(User user, Long id) {
+        try {
+            var field = User.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(user, id);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/homeprotectors/backend/service/NotificationDispatchServiceTest.java
+++ b/src/test/java/com/homeprotectors/backend/service/NotificationDispatchServiceTest.java
@@ -1,0 +1,84 @@
+package com.homeprotectors.backend.service;
+
+import com.homeprotectors.backend.dto.notification.DailyChoreReminderTarget;
+import com.homeprotectors.backend.dto.notification.DailyReminderDispatchSummary;
+import com.homeprotectors.backend.dto.notification.PushNotificationResult;
+import com.homeprotectors.backend.entity.DevicePlatform;
+import com.homeprotectors.backend.entity.DeviceToken;
+import com.homeprotectors.backend.entity.NotificationDeliveryLog;
+import com.homeprotectors.backend.entity.NotificationDeliveryStatus;
+import com.homeprotectors.backend.repository.DeviceTokenRepository;
+import com.homeprotectors.backend.repository.NotificationDeliveryLogRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationDispatchServiceTest {
+
+    @Mock
+    private DailyNotificationTargetService dailyNotificationTargetService;
+
+    @Mock
+    private PushNotificationService pushNotificationService;
+
+    @Mock
+    private NotificationDeliveryLogRepository notificationDeliveryLogRepository;
+
+    @Mock
+    private DeviceTokenRepository deviceTokenRepository;
+
+    @InjectMocks
+    private NotificationDispatchService notificationDispatchService;
+
+    @Test
+    void dispatchDailyChoreReminders_savesLogAndDisablesInvalidTokens() {
+        DailyChoreReminderTarget target = new DailyChoreReminderTarget(
+                10L,
+                List.of("token-1", "token-2"),
+                2L,
+                "오늘 할 일 알림",
+                "오늘 할 일 2건 확인하세요"
+        );
+
+        DeviceToken invalidToken = new DeviceToken();
+        invalidToken.setId(1L);
+        invalidToken.setUserId(10L);
+        invalidToken.setPlatform(DevicePlatform.IOS);
+        invalidToken.setPushToken("token-2");
+        invalidToken.setEnabled(true);
+
+        when(dailyNotificationTargetService.getDailyChoreReminderTargets()).thenReturn(List.of(target));
+        when(pushNotificationService.send(any()))
+                .thenReturn(new PushNotificationResult(1, 1, List.of("token-2"), List.of("token-2")));
+        when(deviceTokenRepository.findByPushTokenIn(List.of("token-2")))
+                .thenReturn(List.of(invalidToken));
+
+        DailyReminderDispatchSummary summary = notificationDispatchService.dispatchDailyChoreReminders();
+
+        assertThat(summary.targetUserCount()).isEqualTo(1);
+        assertThat(summary.successCount()).isEqualTo(1);
+        assertThat(summary.failureCount()).isEqualTo(1);
+        assertThat(summary.items()).hasSize(1);
+        assertThat(summary.items().getFirst().invalidTokens()).containsExactly("token-2");
+
+        ArgumentCaptor<NotificationDeliveryLog> logCaptor = ArgumentCaptor.forClass(NotificationDeliveryLog.class);
+        verify(notificationDeliveryLogRepository).save(logCaptor.capture());
+        assertThat(logCaptor.getValue().getUserId()).isEqualTo(10L);
+        assertThat(logCaptor.getValue().getStatus()).isEqualTo(NotificationDeliveryStatus.SENT);
+        assertThat(logCaptor.getValue().getBody()).isEqualTo("오늘 할 일 2건 확인하세요");
+
+        verify(deviceTokenRepository).saveAll(any());
+        assertThat(invalidToken.getEnabled()).isFalse();
+    }
+}


### PR DESCRIPTION
## 🔍 Overview
 - Add a backend push notification flow for daily chore reminders.                                                                                                                                   
 - This PR covers token storage, target selection, FCM dispatch, scheduled execution, and a manual dispatch endpoint for testing. 

## ✨ Changes
  - Added push notification entities, repositories, and production SQL for `device_tokens` and `notification_delivery_logs`                                                                           
  - Added push token register/delete API                                                                                                                                                              
  - Added daily reminder target selection logic based on active tokens and due chores                                                                                                                 
  - Added FCM push dispatch services with invalid token cleanup                                                                                                                                       
  - Added 07:00 KST scheduled dispatch flow                                                                                                                                                           
  - Added manual dispatch endpoint for testing                                                                                                                                                        
  - Added unit tests for notification targeting and dispatch flow 