### PR TITLE
🐛fix: advance chore nextDue when completed within current cycle

### DIFF
--- a/src/main/java/com/homeprotectors/backend/service/ChoreScheduleCalculator.java
+++ b/src/main/java/com/homeprotectors/backend/service/ChoreScheduleCalculator.java
@@ -32,20 +32,17 @@ public class ChoreScheduleCalculator {
         };
     }
 
-    public LocalDate calculateNextDue(RecurrenceType type, Set<String> selectedCycle, LocalDate doneDate) {
+    public LocalDate calculateNextDue(RecurrenceType type, Set<String> selectedCycle, LocalDate doneDate, LocalDate currentNextDue) {
+        LocalDate effectiveDue = currentNextDue != null && currentNextDue.isAfter(doneDate) ? currentNextDue : doneDate;
         return switch (type) {
-            case PER_WEEK -> doneDate.plusDays(7);
-            case PER_2WEEKS -> doneDate.plusDays(14);
-            case PER_MONTH -> doneDate.plusDays(30);
-            case FIXED_DAY -> findNextDayOfWeek(doneDate, selectedCycle);
-            case FIXED_DATE -> {
-                int day = doneDate.getDayOfMonth();
-                LocalDate nextMonth = doneDate.plusMonths(1);
-                yield nextMonth.withDayOfMonth(Math.min(day, nextMonth.lengthOfMonth()));
-            }
+            case PER_WEEK -> effectiveDue.plusDays(7);
+            case PER_2WEEKS -> effectiveDue.plusDays(14);
+            case PER_MONTH -> effectiveDue.plusDays(30);
+            case FIXED_DAY -> findNextDayOfWeek(effectiveDue, selectedCycle);
+            case FIXED_DATE -> nextDateByDateTokens(effectiveDue.plusDays(1), selectedCycle);
             case FIXED_MONTH -> {
-                int anchor = doneDate.getDayOfMonth();
-                LocalDate candidate = findNextSelectedMonth(doneDate, selectedCycle);
+                int anchor = effectiveDue.getDayOfMonth();
+                LocalDate candidate = findNextSelectedMonth(effectiveDue.plusDays(1), selectedCycle);
                 yield candidate.withDayOfMonth(Math.min(anchor, candidate.lengthOfMonth()));
             }
         };

--- a/src/main/java/com/homeprotectors/backend/service/ChoreService.java
+++ b/src/main/java/com/homeprotectors/backend/service/ChoreService.java
@@ -123,7 +123,12 @@ public class ChoreService {
             throw new IllegalArgumentException("doneDate cannot be in the future.");
         }
 
-        LocalDate newNextDue = choreScheduleCalculator.calculateNextDue(chore.getRecurrenceType(), chore.getSelectedCycle(), doneDate);
+        LocalDate newNextDue = choreScheduleCalculator.calculateNextDue(
+                chore.getRecurrenceType(),
+                chore.getSelectedCycle(),
+                doneDate,
+                chore.getNextDue()
+        );
         chore.setNextDue(newNextDue);
         choreRepository.save(chore);
 

--- a/src/test/java/com/homeprotectors/backend/service/ChoreScheduleCalculatorTest.java
+++ b/src/test/java/com/homeprotectors/backend/service/ChoreScheduleCalculatorTest.java
@@ -1,0 +1,74 @@
+package com.homeprotectors.backend.service;
+
+import com.homeprotectors.backend.entity.RecurrenceType;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ChoreScheduleCalculatorTest {
+
+    private final ChoreScheduleCalculator calculator = new ChoreScheduleCalculator();
+
+    @Test
+    void fixedDayEarlyCompletionMovesToFollowingOccurrence() {
+        LocalDate nextDue = calculator.calculateNextDue(
+                RecurrenceType.FIXED_DAY,
+                Set.of("SUNDAY"),
+                LocalDate.of(2026, 4, 11),
+                LocalDate.of(2026, 4, 12)
+        );
+
+        assertEquals(LocalDate.of(2026, 4, 19), nextDue);
+    }
+
+    @Test
+    void fixedDayOnDueDateMovesOneWeekLater() {
+        LocalDate nextDue = calculator.calculateNextDue(
+                RecurrenceType.FIXED_DAY,
+                Set.of("SUNDAY"),
+                LocalDate.of(2026, 4, 12),
+                LocalDate.of(2026, 4, 12)
+        );
+
+        assertEquals(LocalDate.of(2026, 4, 19), nextDue);
+    }
+
+    @Test
+    void intervalEarlyCompletionUsesCurrentDueAsAnchor() {
+        LocalDate nextDue = calculator.calculateNextDue(
+                RecurrenceType.PER_WEEK,
+                Set.of(),
+                LocalDate.of(2026, 4, 11),
+                LocalDate.of(2026, 4, 12)
+        );
+
+        assertEquals(LocalDate.of(2026, 4, 19), nextDue);
+    }
+
+    @Test
+    void intervalLateCompletionUsesDoneDateAsAnchor() {
+        LocalDate nextDue = calculator.calculateNextDue(
+                RecurrenceType.PER_WEEK,
+                Set.of(),
+                LocalDate.of(2026, 4, 14),
+                LocalDate.of(2026, 4, 12)
+        );
+
+        assertEquals(LocalDate.of(2026, 4, 21), nextDue);
+    }
+
+    @Test
+    void fixedDateEarlyCompletionMovesToNextConfiguredDate() {
+        LocalDate nextDue = calculator.calculateNextDue(
+                RecurrenceType.FIXED_DATE,
+                Set.of("5"),
+                LocalDate.of(2026, 4, 3),
+                LocalDate.of(2026, 4, 5)
+        );
+
+        assertEquals(LocalDate.of(2026, 5, 5), nextDue);
+    }
+}


### PR DESCRIPTION
## 🔍 Overview
This PR fixes chore nextDue calculation when a chore is completed early.                                                                                                          
Previously, completing a chore before its due date could leave nextDue unchanged. Now, completing within the current cycle moves the chore to the next cycle as expected.         
                                                                                                                                                                                                                                                                                                   
## ✨ Changes                                                                                                                                                                                                                                                                                                                                                
  - Updated chore completion logic to advance nextDue based on the current cycle                                                                                                    
  - Fixed FIXED_DAY early-completion behavior                                                                                                                                       
  - Added tests for early completion scheduling 