### PR TITLE
✨feat: update push notification toggle API to use current user token

### DIFF
--- a/src/main/java/com/homeprotectors/backend/controller/PushTokenController.java
+++ b/src/main/java/com/homeprotectors/backend/controller/PushTokenController.java
@@ -48,12 +48,11 @@ public class PushTokenController {
     }
 
     @Operation(summary = "Push token 알림 on/off", description = "Enable or disable push notifications for one of the current user's push tokens")
-    @PatchMapping("/{tokenId}/enabled")
+    @PatchMapping("/me/enabled")
     public ResponseEntity<ResponseDTO<PushTokenResponse>> updateTokenEnabled(
-            @PathVariable Long tokenId,
             @Valid @RequestBody PushTokenEnabledUpdateRequest request,
             @RequestAttribute("currentUserId") UUID currentUserId) {
-        PushTokenResponse response = pushTokenService.updateTokenEnabled(tokenId, request, currentUserId);
+        PushTokenResponse response = pushTokenService.updateTokenEnabled(request, currentUserId);
         return ResponseEntity.ok(new ResponseDTO<>(true, "Push token notification setting updated", response));
     }
 }

--- a/src/main/java/com/homeprotectors/backend/dto/notification/PushTokenEnabledUpdateRequest.java
+++ b/src/main/java/com/homeprotectors/backend/dto/notification/PushTokenEnabledUpdateRequest.java
@@ -1,8 +1,12 @@
 package com.homeprotectors.backend.dto.notification;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record PushTokenEnabledUpdateRequest(
+        @NotBlank(message = "pushToken is required")
+        String pushToken,
+
         @NotNull(message = "enabled is required")
         Boolean enabled
 ) {}

--- a/src/main/java/com/homeprotectors/backend/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/homeprotectors/backend/repository/DeviceTokenRepository.java
@@ -12,6 +12,8 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> 
 
     Optional<DeviceToken> findByIdAndUserId(Long id, Long userId);
 
+    Optional<DeviceToken> findByPushTokenAndUserId(String pushToken, Long userId);
+
     List<DeviceToken> findByUserIdAndEnabledTrue(Long userId);
 
     List<DeviceToken> findByEnabledTrueAndLastSeenAtAfter(OffsetDateTime threshold);

--- a/src/main/java/com/homeprotectors/backend/service/PushTokenService.java
+++ b/src/main/java/com/homeprotectors/backend/service/PushTokenService.java
@@ -50,12 +50,12 @@ public class PushTokenService {
 
     @Transactional
     public PushTokenResponse updateTokenEnabled(
-            Long tokenId,
             PushTokenEnabledUpdateRequest request,
             UUID currentUserId
     ) {
         Long userId = userContextService.requireInternalUserId(currentUserId);
-        DeviceToken token = deviceTokenRepository.findByIdAndUserId(tokenId, userId)
+        String normalizedPushToken = request.pushToken().trim();
+        DeviceToken token = deviceTokenRepository.findByPushTokenAndUserId(normalizedPushToken, userId)
                 .orElseThrow(() -> new EntityNotFoundException("Push token not found"));
 
         token.setEnabled(request.enabled());

--- a/src/test/java/com/homeprotectors/backend/controller/PushTokenControllerIntegrationTest.java
+++ b/src/test/java/com/homeprotectors/backend/controller/PushTokenControllerIntegrationTest.java
@@ -66,11 +66,12 @@ class PushTokenControllerIntegrationTest {
         token.setLastSeenAt(OffsetDateTime.now());
         token = deviceTokenRepository.saveAndFlush(token);
 
-        mockMvc.perform(patch("/api/push-tokens/{tokenId}/enabled", token.getId())
+        mockMvc.perform(patch("/api/push-tokens/me/enabled")
                         .requestAttr("currentUserId", user.getPublicId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
+                                  "pushToken": "integration-token-1",
                                   "enabled": false
                                 }
                                 """))
@@ -96,11 +97,12 @@ class PushTokenControllerIntegrationTest {
         token.setLastSeenAt(OffsetDateTime.now());
         token = deviceTokenRepository.saveAndFlush(token);
 
-        mockMvc.perform(patch("/api/push-tokens/{tokenId}/enabled", token.getId())
+        mockMvc.perform(patch("/api/push-tokens/me/enabled")
                         .requestAttr("currentUserId", anotherUser.getPublicId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
+                                  "pushToken": "integration-token-2",
                                   "enabled": false
                                 }
                                 """))

--- a/src/test/java/com/homeprotectors/backend/controller/PushTokenControllerTest.java
+++ b/src/test/java/com/homeprotectors/backend/controller/PushTokenControllerTest.java
@@ -46,16 +46,16 @@ class PushTokenControllerTest {
 
         given(userContextService.requireInternalUserId(eq(currentUserId))).willReturn(1L);
         given(pushTokenService.updateTokenEnabled(
-                eq(tokenId),
                 org.mockito.ArgumentMatchers.any(),
                 eq(currentUserId)
         )).willReturn(new PushTokenResponse(tokenId, DevicePlatform.IOS, false));
 
-        mockMvc.perform(patch("/api/push-tokens/{tokenId}/enabled", tokenId)
+        mockMvc.perform(patch("/api/push-tokens/me/enabled")
                         .requestAttr("currentUserId", currentUserId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
+                                  "pushToken": "controller-test-token",
                                   "enabled": false
                                 }
                                 """))


### PR DESCRIPTION
## 🔍 Overview
 This PR updates the push notification toggle API so clients can enable or disable notifications without storing a token ID.

## ✨ Changes                                                                                                                                                                     
  - Updated push notification toggle API to use the current user route
  - Changed the request to use `pushToken` instead of `tokenId`                                                                                                                     
  - Added and updated backend tests
