### PR TITLE
🐛fix: tighten auth paths and allow empty chore cycles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+DATABASE_URL=jdbc:postgresql://localhost:5432/postgres
+DATABASE_USERNAME=postgres
+DATABASE_PASSWORD=replace-with-local-db-password
+SPRING_PROFILES_ACTIVE=local
+APP_JWT_PRIVATE_PEM_PATH=./secrets/jwt_private.pem
+APP_JWT_PUBLIC_PEM_PATH=./secrets/jwt_public.pem
+APP_PUSH_ENABLED=false
+APP_PUSH_FCM_CREDENTIALS_PATH=/absolute/path/to/firebase-service-account.json
+APP_PUSH_FCM_PROJECT_ID=replace-with-firebase-project-id
+APP_PUSH_MANUAL_DISPATCH_ENABLED=false
+APP_PUSH_MANUAL_DISPATCH_SECRET=replace-with-long-random-secret

--- a/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCreateRequest.java
+++ b/src/main/java/com/homeprotectors/backend/dto/chore/ChoreCreateRequest.java
@@ -4,7 +4,6 @@ import com.homeprotectors.backend.entity.RecurrenceType;
 import com.homeprotectors.backend.entity.RoomCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -27,7 +26,6 @@ public class ChoreCreateRequest {
     private RecurrenceType recurrenceType;
 
     @NotNull(message = "selectedCycle is required")
-    @NotEmpty(message = "selectedCycle must not be empty")
     private Set<String> selectedCycle;
 
     @NotNull(message = "roomCategory is required")

--- a/src/main/java/com/homeprotectors/backend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/homeprotectors/backend/security/JwtAuthenticationFilter.java
@@ -28,8 +28,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final Set<String> publicPaths = Set.of(
             "/api/guests/register",
             "/api/auth/refresh",
-            "/api/admin/notifications/daily-chore-reminder/dispatch",
-            "/api/admin/notifications/daily-chore-reminder/test-dispatch",
             "/actuator/health"
     );
 

--- a/src/test/java/com/homeprotectors/backend/controller/ChoreControllerIntegrationTest.java
+++ b/src/test/java/com/homeprotectors/backend/controller/ChoreControllerIntegrationTest.java
@@ -1,0 +1,74 @@
+package com.homeprotectors.backend.controller;
+
+import com.homeprotectors.backend.entity.Group;
+import com.homeprotectors.backend.entity.User;
+import com.homeprotectors.backend.repository.GroupRepository;
+import com.homeprotectors.backend.repository.UserRepository;
+import com.homeprotectors.backend.service.JwtTokenService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class ChoreControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @MockBean
+    private JwtTokenService jwtTokenService;
+
+    @AfterEach
+    void tearDown() {
+        jdbcTemplate.update("delete from chores");
+        userRepository.deleteAll();
+        groupRepository.deleteAll();
+    }
+
+    @Test
+    void createChore_allowsEmptySelectedCycleForPerTwoWeeks() throws Exception {
+        Group group = groupRepository.save(new Group(null, null, "My Home", "INVITE21", null, null));
+        User user = userRepository.saveAndFlush(new User(UUID.randomUUID(), UUID.randomUUID(), group.getId()));
+
+        mockMvc.perform(post("/api/chores")
+                        .requestAttr("currentUserId", user.getPublicId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title": "Vacuum",
+                                  "recurrenceType": "PER_2WEEKS",
+                                  "selectedCycle": [],
+                                  "roomCategory": "ETC"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.recurrenceType").value("PER_2WEEKS"))
+                .andExpect(jsonPath("$.data.selectedCycle").isArray())
+                .andExpect(jsonPath("$.data.selectedCycle").isEmpty());
+    }
+}

--- a/src/test/java/com/homeprotectors/backend/security/JwtAuthenticationFilterIntegrationTest.java
+++ b/src/test/java/com/homeprotectors/backend/security/JwtAuthenticationFilterIntegrationTest.java
@@ -1,0 +1,38 @@
+package com.homeprotectors.backend.security;
+
+import com.homeprotectors.backend.service.JwtTokenService;
+import com.homeprotectors.backend.service.NotificationDispatchService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class JwtAuthenticationFilterIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtTokenService jwtTokenService;
+
+    @MockBean
+    private NotificationDispatchService notificationDispatchService;
+
+    @Test
+    void adminNotificationDispatch_requiresAuthorizationHeader() throws Exception {
+        mockMvc.perform(post("/api/admin/notifications/daily-chore-reminder/dispatch"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Authorization header is required."));
+    }
+}


### PR DESCRIPTION
## 🔍 Overview
This PR fixes chore creation for interval-based recurrence types and tightens admin notification dispatch access.

## ✨ Changes
  - Allowed empty `selectedCycle` for interval chores
  - Removed admin dispatch endpoints from public auth paths
  - Added related tests and `.env.example`